### PR TITLE
fixed bone shield triggering cd when already on cd

### DIFF
--- a/src/lua/CommunityBalanceMod/FileHooks.lua
+++ b/src/lua/CommunityBalanceMod/FileHooks.lua
@@ -243,6 +243,7 @@ Loader_SetupFilehook( "lua/Weapons/Alien/Gore.lua", "post", folder ) -- focus de
 Loader_SetupFilehook( "lua/Weapons/Alien/StabBlink.lua", "post", folder ) -- focus applies to stab
 Loader_SetupFilehook( "lua/Babbler.lua", "post", folder ) -- attached babblers on other aliens dont jiggle
 Loader_SetupFilehook( "lua/UmbraMixin.lua", "post", folder ) -- finetunes umbra for cloaked aliens
+Loader_SetupFilehook( "lua/Weapons/BoneShield.lua", "post", folder ) -- fixed bone shield triggering cooldown when already on cooldown
 -- pulse_gre_elec.surface_shader    increased visibility on model
 
 

--- a/src/lua/CommunityBalanceMod/TwiliteFix/BoneShield.lua
+++ b/src/lua/CommunityBalanceMod/TwiliteFix/BoneShield.lua
@@ -1,0 +1,39 @@
+local oldOnCreate = BoneShield.OnCreate
+function BoneShield:OnCreate()
+    oldOnCreate(self)
+    --tiny delay, to allow clean swap-state when changing abilities
+    self.onDrawTime = 0
+    
+end
+
+function BoneShield:OnDraw(player, previousWeaponMapName)
+    Ability.OnDraw(self, player, previousWeaponMapName)
+    --self.secondaryAttacking = false
+    self.primaryAttacking = false
+    self.onDrawTime = Shared.GetTime()
+end
+
+function BoneShield:OnPrimaryAttackEnd()
+    if self.primaryAttacking then
+        self.lastTimeDeactivated = Shared.GetTime()
+        self.primaryAttacking = false
+        self:UpdateHitpointsRechargeStartTime()
+    end
+end
+
+local kOnDrawStompActivateDelay = 0 -- 0.055555
+
+function BoneShield:OnUpdateAnimationInput(modelMixin)
+
+    local now = Shared.GetTime()
+    --[[if self.onDrawTime + kOnDrawStompActivateDelay > now then
+        return
+    end--]]
+    
+    local activityString = self.primaryAttacking and "primary" or "none"
+    local abilityString = "boneshield"
+       
+    modelMixin:SetAnimationInput("ability", abilityString)
+    modelMixin:SetAnimationInput("activity", activityString)
+
+end


### PR DESCRIPTION
fixed bone shield triggering cooldown when already on cooldown.

Before if an onos tried to activate boneshield multiple times, each failed attempt would restart the cooldown from 0 which prevented it to use boneshield until it stops spamming the ability for the entire cooldown duration.