### PR TITLE
Hallucination improvements

### DIFF
--- a/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanderBrain_Senses.lua
+++ b/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanderBrain_Senses.lua
@@ -1,0 +1,19 @@
+
+local oldCreateMarineComSenses = CreateMarineComSenses
+function CreateMarineComSenses()
+
+
+    local s = oldCreateMarineComSenses()
+
+    s:Add("mainAdvancedPrototypeLab", function(db)
+        local startingLocationId = Shared.GetStringIndex(db.bot.brain:GetStartingTechPoint() or "")
+        local units = GetEntitiesAliveForTeamByLocationWithTechId( "PrototypeLab", db.bot:GetTeamNumber(), startingLocationId, kTechId.AdvancedPrototypeLab )
+        if #units > 0 then
+            return units[1]
+        end
+    end)
+
+  
+    return s
+
+end

--- a/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanerBrain_TechPath.lua
+++ b/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanerBrain_TechPath.lua
@@ -1,0 +1,80 @@
+
+local kMarineCommanderTechPath =
+{
+    -- Tier 1 (Early Game)
+    {
+        kTechId.ArmsLab,
+        kTechId.Armor1,
+        kTechId.Armory,
+    },
+
+    -- Tier 2
+    {
+        -- Phase Tech
+        kTechId.Observatory,
+        kTechId.PhaseTech,
+
+        kTechId.Weapons1,
+        kTechId.PhaseGate,
+        kTechId.MinesTech,
+        kTechId.Armor2,
+    },
+
+    -- Tier 3
+    {
+        -- Auxillary stuff
+        kTechId.ShotgunTech,
+        kTechId.Weapons2,
+        kTechId.GrenadeTech,
+    },
+
+    -- Tier 4
+    {
+        kTechId.AdvancedArmoryUpgrade, -- Flamethrower, GL, HMG all unlocked by this upgrade
+        kTechId.PrototypeLab,
+    },
+
+    -- Tier 5
+    {
+        kTechId.JetpackTech,
+        kTechId.UpgradeToAdvancedPrototypeLab, --Balance Mod
+        --kTechId.ExosuitTech, --Balance Mod
+        kTechId.AdvancedMarineSupport, -- Nanoshield, Powersurge, Catpack
+        kTechId.Weapons3,
+        kTechId.Armor3,
+    },
+}
+
+
+local NewGetTechPath = debug.getupvaluex(GetMarineComNextTechStep, "GetTechPath")
+debug.setupvaluex(NewGetTechPath, "kMarineCommanderTechPath", kMarineCommanderTechPath)
+
+debug.setupvaluex(GetMarineComNextTechStep, "GetTechPath", NewGetTechPath)
+
+
+
+local kTechTestReroutes =
+{
+    [kTechId.AdvancedArmoryUpgrade] = kTechId.AdvancedArmory,
+    [kTechId.UpgradeToAdvancedPrototypeLab] = kTechId.AdvancedPrototypeLab --Balance Mod
+}
+
+local kBuildTechIdToSenseMap =
+{
+    [kTechId.ArmsLab]            = "mainArmsLab"           ,
+    [kTechId.Armory]             = "mainArmory"            ,
+    [kTechId.Observatory]        = "mainObservatory"       ,
+    [kTechId.PhaseGate]          = "mainPhaseGate"         ,
+    [kTechId.AdvancedArmory]     = "mainAdvancedArmory"    ,
+    [kTechId.PrototypeLab]       = "mainPrototypeLab"      ,
+    [kTechId.AdvancedPrototypeLab]= "mainAdvancedPrototypeLab", --Balance Mod
+    --[kTechId.RoboticsFactory]    = "hasRoboticsFactoryInBase"   ,
+    --[kTechId.ARCRoboticsFactory] = "hasARCRoboticsFactoryInBase",
+}
+
+local NewGetHasTechForMarineTechPath = debug.getupvaluex(GetMarineComNextTechStep, "GetHasTechForMarineTechPath")
+debug.setupvaluex(NewGetHasTechForMarineTechPath, "kTechTestReroutes", kTechTestReroutes)
+debug.setupvaluex(NewGetHasTechForMarineTechPath, "kBuildTechIdToSenseMap", kBuildTechIdToSenseMap)
+
+
+debug.setupvaluex(GetMarineComNextTechStep, "GetHasTechForMarineTechPath", NewGetHasTechForMarineTechPath)

--- a/src/lua/CommunityBalanceMod/FileHooks.lua
+++ b/src/lua/CommunityBalanceMod/FileHooks.lua
@@ -212,6 +212,8 @@ Loader_SetupFilehook("lua/TechTreeButtons.lua", "post", folder)
 -- TechTreeConstants.lua 
 -- TechTree.lua 
 -- TeamInfo.lua
+Loader_SetupFilehook("lua/bots/MarineCommanderBrain_Senses.lua", "post", folder)
+Loader_SetupFilehook("lua/bots/MarineCommanerBrain_TechPath.lua", "post", folder)
 Loader_SetupFilehook("lua/Balance.lua", "post", folder)
 Loader_SetupFilehook("lua/TechData.lua", "post", folder)
 Loader_SetupFilehook("lua/ServerStats.lua", "post", folder)

--- a/src/lua/CommunityBalanceMod/FortressPvE/AlienTeam.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/AlienTeam.lua
@@ -65,6 +65,7 @@ function AlienTeam:InitTechTree()
     self.techTree:AddTargetedActivation(kTechId.MucousMembrane,   kTechId.CragHive,      kTechId.None)
     --self.techTree:AddTargetedActivation(kTechId.Storm,            kTechId.ShiftHive,       kTechId.None)
     self.techTree:AddActivation(kTechId.DestroyHallucination)
+    self.techTree:AddActivation(kTechId.HallucinateRandom)
     self.techTree:AddTargetedActivation(kTechId.HallucinateCloning)
 
     -- Cyst passives

--- a/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
@@ -22,6 +22,6 @@ kWhipAbilityCost = 3
 kWhipAbilityCooldown = 10
 
 kHallucinateCloningCost = 0
-kHallucinateCloningCooldown = 1
+kHallucinateCloningCooldown = 1.5
 kHallucinateRandomCost = 0
 kHallucinateRandomCooldown = 1.5

--- a/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
@@ -14,7 +14,7 @@ kWhipCost = 8
 kCragUmbra = 5
 
 kMaxHallucinations = 6
-kHallucinationLifeTime = 600
+kHallucinationLifeTime = 0.1 -- ignored, last indefinitely
 
 kStormCloudDuration = 9.5
 
@@ -23,3 +23,5 @@ kWhipAbilityCooldown = 10
 
 kHallucinateCloningCost = 0
 kHallucinateCloningCooldown = 1
+kHallucinateRandomCost = 0
+kHallucinateRandomCooldown = 1.5

--- a/src/lua/CommunityBalanceMod/FortressPvE/BalanceMisc.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/BalanceMisc.lua
@@ -1,3 +1,4 @@
-kHallucinationHealthFraction = 0.4 --0.20
-kHallucinationArmorFraction = 0.1
-kHallucinationMaxHealth = 250 --700
+kHallucinationHealthFraction = 1.0 --0.4
+kHallucinationArmorFraction = 1.0 --0.1
+kHallucinationMaxHealth = 2000 --700
+kHallucinationDamageMulti = 3.66 -- hallucinations take more damage

--- a/src/lua/CommunityBalanceMod/FortressPvE/Hallucination.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Hallucination.lua
@@ -27,6 +27,7 @@ Script.Load("lua/MapBlipMixin.lua")
 Script.Load("lua/CloakableMixin.lua")
 Script.Load("lua/TargetCacheMixin.lua")
 Script.Load("lua/UnitStatusMixin.lua")
+Script.Load("lua/DetectableMixin.lua")
 
 PrecacheAsset("cinematics/vfx_materials/hallucination.surface_shader")
 local kHallucinationMaterial = PrecacheAsset( "cinematics/vfx_materials/hallucination.material")
@@ -66,6 +67,7 @@ AddMixinNetworkVars(OrdersMixin, networkVars)
 AddMixinNetworkVars(LOSMixin, networkVars)
 AddMixinNetworkVars(SelectableMixin, networkVars)
 AddMixinNetworkVars(CloakableMixin, networkVars)
+AddMixinNetworkVars(DetectableMixin, networkVars)
 
 local gTechIdAttacking
 local function GetTechIdAttacks(techId)
@@ -341,6 +343,7 @@ function Hallucination:OnCreate()
     InitMixin(self, LOSMixin)
     InitMixin(self, SoftTargetMixin)
     InitMixin(self, CloakableMixin)
+    InitMixin(self, DetectableMixin)
     
     if Server then
 		

--- a/src/lua/CommunityBalanceMod/FortressPvE/Hallucination.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Hallucination.lua
@@ -26,6 +26,7 @@ Script.Load("lua/SoftTargetMixin.lua")
 Script.Load("lua/MapBlipMixin.lua")
 Script.Load("lua/CloakableMixin.lua")
 Script.Load("lua/TargetCacheMixin.lua")
+Script.Load("lua/UnitStatusMixin.lua")
 
 PrecacheAsset("cinematics/vfx_materials/hallucination.surface_shader")
 local kHallucinationMaterial = PrecacheAsset( "cinematics/vfx_materials/hallucination.material")
@@ -132,6 +133,18 @@ techIdToHallucinateId[kTechId.FortressWhip] = kTechId.HallucinateWhip
 techIdToHallucinateId[kTechId.FortressShade] = kTechId.HallucinateShade
 techIdToHallucinateId[kTechId.FortressCrag] = kTechId.HallucinateCrag
 techIdToHallucinateId[kTechId.FortressShift] = kTechId.HallucinateShift
+
+local hallucinateStructureTypes = {
+    kTechId.HallucinateShade,
+    kTechId.HallucinateWhip,
+    kTechId.HallucinateCrag,
+    kTechId.HallucinateShift,
+    kTechId.HallucinateShell,
+    kTechId.HallucinateSpur,
+    kTechId.HallucinateVeil,
+    kTechId.HallucinateDrifter,
+    kTechId.HallucinateEgg,
+}
 
 local gTechIdCanMove
 local function GetHallucinationCanMove(techId)
@@ -255,20 +268,28 @@ local function SetAssignedAttributes(self, hallucinationTechId, reset)
 
     -- hallucinationTechId is ignored...
     local model = LookupTechData(self.assignedTechId, kTechDataModel, Shade.kModelName)
-    local health = math.min(LookupTechData(self.assignedTechId, kTechDataMaxHealth, kShadeHealth) * kHallucinationHealthFraction, kHallucinationMaxHealth)
-    local armor = LookupTechData(self.assignedTechId, kTechDataMaxArmor, kShadeArmor) * kHallucinationArmorFraction
-    
+    local hallucinatedTechDataId = techIdToHallucinateId[self.assignedTechId]
+    local health = hallucinatedTechDataId and LookupTechData(hallucinatedTechDataId, kTechDataMaxHealth)
+                    or math.min(LookupTechData(self.assignedTechId, kTechDataMaxHealth, kMatureShadeHealth) * kHallucinationHealthFraction, kHallucinationMaxHealth)
+    local armor = hallucinatedTechDataId and LookupTechData(hallucinatedTechDataId, kTechDataMaxArmor)
+                    or LookupTechData(self.assignedTechId, kTechDataMaxArmor, kMatureShadeArmor) * kHallucinationArmorFraction
+		
     self.maxSpeed = GetMaxMovementSpeed(self.assignedTechId)    
     self:SetModel(model, GetAnimationGraph(self.assignedTechId))
 
     -- do not reset health when changing model
-    if (reset == true) or not self.emulationDone then
+    --[[if (reset == true) or not self.emulationDone then
         self:SetMaxHealth(health)
         self:SetHealth(health)
         self:SetMaxArmor(armor)
         self:SetArmor(armor)
-    end
+    end--]]
 	
+    self:SetMaxHealth(health)
+    self:SetHealth(health * self.storedHealthFraction)
+    self:SetMaxArmor(armor)
+    self:SetArmor(armor * self.storedArmorScalar)
+        
     if self.assignedTechId == kTechId.Hive then
 
         local attachedTechPoint = self:GetAttached()
@@ -328,7 +349,10 @@ function Hallucination:OnCreate()
         self.attacking = false
         self.moving = false
         self.assignedTechId = kTechId.Shade --kTechId.Skulk
-
+        
+        self.storedHealthFraction = 1
+        self.storedArmorScalar = 1
+        
         InitMixin(self, SleeperMixin)
         
     end
@@ -362,6 +386,9 @@ function Hallucination:OnInitialized()
                 Hallucination.kSpotRange,
                 true, 
                 { kAlienStaticTargets, kAlienMobileTargets })
+                
+    elseif Client then
+        InitMixin(self, UnitStatusMixin)
     end
     
     self:SetPhysicsGroup(PhysicsGroup.SmallStructuresGroup)
@@ -467,7 +494,7 @@ function Hallucination:OnUpdate(deltaTime)
 
     if Server then
         self:UpdateServer(deltaTime)
-        UpdateHallucinationLifeTime(self)
+        --UpdateHallucinationLifeTime(self)
     elseif Client then
         self:UpdateClient(deltaTime)
     end    
@@ -528,7 +555,23 @@ function Hallucination:PerformActivation(techId, position, normal, commander)
 
             return true, true
         end
+        
+    elseif techId == kTechId.HallucinateRandom then
+        
+        local cooldown = LookupTechData(techId, kTechDataCooldown, 0)
 
+        if commander and cooldown ~= 0 then
+            commander:SetTechCooldown(techId, cooldown, Shared.GetTime())
+        end
+        
+        -- remember our health and armour percentage to prevent health gain after changing form
+        self.storedHealthFraction = self:GetHealthFraction()
+        self.storedArmorScalar = (self:GetMaxArmor() == 0) and self.storedArmorScalar or self:GetArmorScalar()
+    
+        local hallucType = hallucinateStructureTypes[ math.random(#hallucinateStructureTypes) ]
+        self:SetEmulation(hallucType)
+        return true, true
+        
     elseif techId == kTechId.DestroyHallucination then
 
         self:Kill()
@@ -562,7 +605,7 @@ end
 
 function Hallucination:GetTechButtons(techId)
 
-    return { kTechId.HallucinateCloning, kTechId.None, kTechId.None, kTechId.None,
+    return { kTechId.HallucinateCloning, kTechId.None, kTechId.HallucinateRandom, kTechId.None,
              kTechId.None, kTechId.None, kTechId.None, kTechId.DestroyHallucination }
     
 end
@@ -596,7 +639,17 @@ function Hallucination:GetIsMoveable()
 end
 
 function Hallucination:OnUpdatePoseParameters()
-    self:SetPoseParam("grow", 1.0)    
+    self:SetPoseParam("grow", 1.0)
+end
+
+function Hallucination:ModifyDamageTaken(damageTable, attacker, doer, damageType, hitPoint)
+
+    local multiplier = self.assignedTechId == kTechId.Egg and 1.16 or
+                       self.assignedTechId == kTechId.Drifter and 1.7 or
+                       kHallucinationDamageMulti
+
+    damageTable.damage = damageTable.damage * multiplier
+
 end
 
 if Server then

--- a/src/lua/CommunityBalanceMod/FortressPvE/Locale.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Locale.lua
@@ -37,4 +37,7 @@ if Client then
 	
     Locale.substitutions["HALLUCINATE_CLONING"] = "Hallucination Cloning"
     Locale.substitutions["HALLUCINATE_CLONING_TOOLTIP"] = "Change Hallucination into a copy of a valid target"
+    
+    Locale.substitutions["HALLUCINATE_RANDOM"] = "Random Hallucination"
+    Locale.substitutions["HALLUCINATE_RANDOM_TOOLTIP"] = "Change Hallucination into a random one"
 end

--- a/src/lua/CommunityBalanceMod/FortressPvE/TechData.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/TechData.lua
@@ -1,10 +1,8 @@
+local removeTechDataValue = "BalanceModRemoveTechData"
 
-local oldBuildTechData = BuildTechData
-function BuildTechData()
-    
-    local techData = oldBuildTechData()    
-
-        table.insert(techData, { 
+local function GetTechToAdd()
+    return {
+        { 
             [kTechDataId] = kTechId.FortressCrag,
             [kTechDataBioMass] = kCragBiomass,
             [kTechDataSupply] = kCragSupply,
@@ -22,10 +20,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_CRAG_TOOLTIP", 
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 1.15, 
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressCrag,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -34,20 +32,20 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_CRAG_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_CRAG_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true,
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressCragAbility,
             [kTechDataCooldown] = kFortressAbilityCooldown, 
             [kTechDataDisplayName] = "FORTRESS_CRAG_ABILITY", 
             [kTechDataCostKey] = kFortressAbilityCost,
             [kTechDataTooltipInfo] = "FORTRESS_CRAG_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressShift,
             [kTechDataBioMass] = kShiftBiomass,
             [kTechDataSupply] = kShiftSupply,
@@ -68,10 +66,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_SHIFT_TOOLTIP", 
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 1.3,
-        })
+        },
 
 
-        table.insert(techData, {  
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressShift,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -80,20 +78,20 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_SHIFT_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_SHIFT_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true,
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressShiftAbility,
             [kTechDataCooldown] = kFortressAbilityCooldown, 
             [kTechDataDisplayName] = "FORTRESS_SHIFT_ABILITY", 
             [kTechDataCostKey] = kFortressAbilityCost,
             [kTechDataTooltipInfo] = "FORTRESS_SHIFT_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressShade,
             [kTechDataBioMass] = kShadeBiomass,
             [kTechDataSupply] = kShadeSupply,
@@ -112,10 +110,10 @@ function BuildTechData()
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 1.25,
             [kTechDataMaxExtents] = Vector(1, 1.3, .4),
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressShade,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -124,13 +122,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_SHADE_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_SHADE_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true, 
-        })
+        },
 
 
-       
-
-
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressWhip,
             [kTechDataBioMass] = kWhipBiomass,
             [kTechDataSupply] = kWhipSupply,
@@ -149,10 +144,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_WHIP_TOOLTIP", 
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 0.85,
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressWhip,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -161,30 +156,30 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_WHIP_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_WHIP_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true, 
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressWhipAbility,
             [kTechDataCooldown] = kFortressAbilityCooldown, 
             [kTechDataDisplayName] = "FORTRESS_WHIP_ABILITY", 
             [kTechDataCostKey] = kFortressAbilityCost,
             [kTechDataTooltipInfo] = "FORTRESS_WHIP_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.WhipAbility,
             [kTechDataCooldown] = kWhipAbilityCooldown, 
             [kTechDataDisplayName] = "WHIP_ABILITY", 
             [kTechDataCostKey] = kWhipAbilityCost,
             [kTechDataTooltipInfo] = "WHIP_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.ShadeHallucination,
             [kTechDataMapName] = ShadeHallucination.kMapName,
             [kTechDataCooldown] = kFortressAbilityCooldown,
@@ -198,9 +193,10 @@ function BuildTechData()
             [kTechDataAllowStacking] = true,
             [kTechDataOneAtATime] = true,
             [kTechDataModel] = BoneWall.kModelName,
-        })
-    
-        table.insert(techData, {
+        },
+
+
+        {
             [kTechDataId] = kTechId.HallucinateShell,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -208,9 +204,12 @@ function BuildTechData()
             [kTechDataModel] = Shell.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
-            
-        table.insert(techData, {
+            [kTechDataMaxHealth] = kMatureShellHealth,
+            [kTechDataMaxArmor] = kMatureShellArmor,
+        },
+
+        
+        {
             [kTechDataId] = kTechId.HallucinateSpur,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -218,9 +217,12 @@ function BuildTechData()
             [kTechDataModel] = Spur.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
-            
-        table.insert(techData, {
+            [kTechDataMaxHealth] = kMatureSpurHealth,
+            [kTechDataMaxArmor] = kMatureSpurArmor,            
+        },
+
+
+        {
             [kTechDataId] = kTechId.HallucinateVeil,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -228,9 +230,12 @@ function BuildTechData()
             [kTechDataModel] = Veil.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
-        
-        table.insert(techData, {
+            [kTechDataMaxHealth] = kMatureVeilHealth,
+            [kTechDataMaxArmor] = kMatureVeilArmor,
+        },
+
+
+        {
             [kTechDataId] = kTechId.HallucinateEgg,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -238,17 +243,140 @@ function BuildTechData()
             [kTechDataModel] = Egg.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
+            [kTechDataMaxHealth] = kEggHealth,
+            [kTechDataMaxArmor] = kEggArmor,
+        },
 
-        table.insert(techData, {
+
+        {
             [kTechDataId] = kTechId.HallucinateCloning,
             [kTechDataDisplayName] = "HALLUCINATE_CLONING",
             [kTechDataTooltipInfo] = "HALLUCINATE_CLONING_TOOLTIP",
             [kTechDataCostKey] = kHallucinateCloningCost,
             [kTechDataCooldown] = kHallucinateCloningCooldown,
             [kTechDataOrderSound] = AlienCommander.kBuildStructureSound,
-        })
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateRandom,
+            [kTechDataDisplayName] = "HALLUCINATE_RANDOM",
+            [kTechDataTooltipInfo] = "HALLUCINATE_RANDOM_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateRandomCost,
+            [kTechDataCooldown] = kHallucinateRandomCooldown,
+            [kTechDataOrderSound] = AlienCommander.kBuildStructureSound,
+        },       
+
+
+        -- Add new values for removed tech
+        {
+            [kTechDataId] = kTechId.HallucinateWhip,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_WHIP",
+            [kTechDataModel] = Whip.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_WHIP_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateWhipEnergyCost,
+            [kTechDataMaxHealth] = kMatureWhipHealth,
+            [kTechDataMaxArmor] = kMatureWhipArmor,
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateShade,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_SHADE",
+            [kTechDataModel] = Shade.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_SHADE_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateShadeEnergyCost,
+            [kTechDataMaxHealth] = kMatureShadeHealth,
+            [kTechDataMaxArmor] = kMatureShadeArmor,
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateCrag,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_CRAG",
+            [kTechDataModel] = Crag.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_CRAG_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateCragEnergyCost,
+            [kTechDataMaxHealth] = kMatureCragHealth,
+            [kTechDataMaxArmor] = kMatureCragArmor,
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateShift,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_SHIFT",
+            [kTechDataModel] = Shift.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateShiftEnergyCost,
+            [kTechDataMaxHealth] = kMatureShiftHealth,
+            [kTechDataMaxArmor] = kMatureShiftArmor,
+        },
+    }
+end
+
+local function GetTechToChange()
+    return {}
+end
+
+local function GetTechToRemove() 
+    return {
+        [kTechId.HallucinateWhip] = true,
+        [kTechId.HallucinateShade] = true,
+        [kTechId.HallucinateCrag] = true,
+        [kTechId.HallucinateShift] = true,
+    }
+end
+
+local function TechDataChanges(techData)
+    -- Handle changes / removes
+    local techToChange = GetTechToChange()
+    local techToRemove = GetTechToRemove()
+    local indexToRemove = {}
+
+    for techIndex,record in ipairs(techData) do
+        local techDataId = record[kTechDataId]
+
+        if techToRemove[techDataId] then
+            table.insert(indexToRemove, techIndex)
+        elseif techToChange[techDataId] then
+            for index, value in pairs(techToChange[techDataId]) do
+                if value == removeTechDataValue then
+                    techData[techIndex][index] = nil
+                else
+                    techData[techIndex][index] = value
+                end
+            end
+        end
+    end
+
+    -- Remove tech
+    local offset = 0
+    for _,idx in ipairs(indexToRemove) do
+        table.remove(techData, idx - offset)
+        offset = offset + 1
+    end
+
+    -- Add new tech
+    local techToAdd = GetTechToAdd()
+    for _,v in ipairs(techToAdd) do
+        table.insert(techData, v)
+    end
+end
+
+local oldBuildTechData = BuildTechData
+function BuildTechData()
+    
+    local techData = oldBuildTechData()    
+        
+    TechDataChanges(techData)
     
     return techData
 end
-


### PR DESCRIPTION
*Added Hallucination Cloning ability - copy the appearance of a valid structure or hallucination (1.5sec cooldown).
*Added Randomize Hallucination ability - change hallucination appearance to a random one (1.5sec cooldown).
*Hallucinations show their healths to enemies to appear like the structures copied.
*Hallucinations have same health & armor as fully matured versions.
*Hallucinations now received increased damage 366% for structures, 116% for eggs, 170% for Drifter. Resulting eHP is approximately 300 (200 for Drifter).
*Time limit of Hallucinations removed.