### PR TITLE
Revision 2.0.3

### DIFF
--- a/configs/dev/CommunityBalanceMod.json
+++ b/configs/dev/CommunityBalanceMod.json
@@ -1,5 +1,5 @@
 {
-    "revision": "2.0.2",
+    "revision": "2.0.3",
     "build_tag": "test",
     "changelog_url": "https://ns2-bdt.github.io/CommunityBalanceMod-testing",
     "revision_changelog_url": "https://ns2-bdt.github.io/CommunityBalanceMod-testing/changelog.html"

--- a/configs/prod/CommunityBalanceMod.json
+++ b/configs/prod/CommunityBalanceMod.json
@@ -1,5 +1,5 @@
 {
-    "revision": "2.0.2",
+    "revision": "2.0.3",
     "changelog_url": "https://ns2-bdt.github.io/CommunityBalanceMod",
     "revision_changelog_url": "https://ns2-bdt.github.io/CommunityBalanceMod/changelog.html"
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,34 @@
+
+# Revision 2.0.3 (2023/12/24)
+## ALIEN
+### Hives
+  - Reduced the additional 10% HP buff for maturity hives to 5%
+
+### Fortress Shade
+  - Hallucinations time duration removed
+  - Able to transform into a random different structure
+  - Added HP bars on hallucinations
+
+### Whips
+  - Increased turning speed before moving
+  - Decreased rooting, unrooting time under frenzy
+  - Reduced the cost of bile splash from 3 to 2 tres
+
+### Fortress Structures
+  - Converted 66% of their armor into HP (huge nerf to healing)
+  - Increased cooldown for all fortress abilities from 10 to 15 seconds
+  - reduced the cost of all fortress abilities from 3 to 2 tres
+  - Fixed a bug which allowed abilities to being cast while under fire
+  - No longer take 3x the damage off infestation in comparison to normal structures
+
+### Drifter
+  - Doesnt follow echoed unfinished structures over the entire map anymore
+  
+## MARINE
+### Bugfixes 
+  - Flying flamethrowers in rare cases should not crash the server anymore (vanilla bug)
+  - Bot Commanders will research Exos, Weapon 3, Armor 3 again (balance mod bug)
+
 # Revision 2.0.2 (2023/11/28)
 
 ## ALIEN

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 
-# Revision 2.0.3 (2023/12/24)
+# Revision 2.0.3 (2023/12/??)
 ## ALIEN
 ### Hives
   - Reduced the additional 10% HP buff for maturity hives to 5%
@@ -19,13 +19,14 @@
   - Reduced the cost of bile splash from 3 to 2 tres
 
 ### Fortress Structures
-  - Converted 66% of their armor into HP (huge nerf to healing)
+  - Converted 50% of their armor into HP (nerf to healing)
   - Increased cooldown for all fortress abilities from 10 to 15 seconds
-  - reduced the cost of all fortress abilities from 3 to 2 tres
+  - Reduced the cost of all fortress abilities from 3 to 2 tres
   - Fixed a bug which allowed abilities to being cast while under fire
   - No longer take 3x the damage off infestation in comparison to normal structures
 
 ### Drifter
+  - Increased mucous area of effect to the same size as enzymes
   - Doesnt follow echoed unfinished structures over the entire map anymore
   
 ## MARINE

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -199,7 +199,7 @@
 
 ### Shade Hive
 - Hallucination Cloud
-  - Replaced Hallucination Cloud with Lesser Ink Cloud, cloaks players, eggs and drifters (including those in combat) for up to 5 seconds
+  - Replaced Hallucination Cloud with Cloaking Haze, cloaks players, eggs and drifters (including those in combat) for up to 5 seconds
   - Hallucinated Hive and Harvester will still spawn in their allocated positions
   - Ink Cloud (& Lesser Ink Cloud) provides enhanced cloaking for 1 second, removes sighted status, and gives improved visual camouflage (minimum 20%) even when in combat
   - Cloaked Whips are more visible (same as players)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 ### Hives
   - Reduced the additional 10% HP buff for maturity hives to 5%
 
+### Stab
+  - Stab research cost reduced from 25 to 20 tres
+  - Stab energy cost reduced by 16%
+
 ### Fortress Shade
   - Hallucinations time duration removed
   - Able to transform into a random different structure

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,10 +84,9 @@
     - Onos: 4 (Changed)
 
 ### Shade Hive
-- Hallucination Cloud
-  - Replaced Hallucination Cloud with Lesser Ink Cloud, cloaks players, eggs and drifters (including those in combat) for up to 5 seconds.
-  - Hallucinated Hive and Harvester will still spawn in their allocated positions.
-  - Ink Cloud (& Lesser Ink Cloud) provides enhanced cloaking for 1 second, removes sighted status, and gives improved visual camouflage (minimum 20%) even when in combat.
+- Cloaking Haze
+  - Replaced Hallucination Cloud with Cloaking Haze, cloaks players, eggs and drifters (including those in combat) for up to 5 seconds.
+  - Ink Cloud (& Cloaking Haze) provides enhanced cloaking for 1 second, removes sighted status, and gives improved visual camouflage (minimum 20%) even when in combat.
   - Cloaked Whips are more visible (same as players).
 
 ### Veil/Spur/Shell

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Changes between revision 2.0.2 and Vanilla Build 344
+# Changes between revision 2.0.3 and Vanilla Build 344
 
 <br>
 <br>
@@ -23,17 +23,18 @@
   - Cannot be echo'd
   - Restricted to max 1 of each kind
   - Are able to use ink, echo and healwave without a hivetype
-  - Access to a new ability with the corresponding hive type (3 tres, 10 sec cooldown)
+  - Access to a new ability with the corresponding hive type (2 tres, 15 sec cooldown)
     - Umbra(Crag): Cast Umbra for 5 seconds on all Structures in healrange
-    - Hallucinations(Shade): Create 6 moveable hallucination Structures (whip or shade likelier) for 600 seconds
+    - Hallucinations(Shade): Create 6 moveable hallucination Structures
     - Stormcloud(Shift): Increase alien movement speed by 20% for 9.5 seconds
     - Frenzy(Whip): 2x attack speed and 2.5x movement speed for 7.5 seconds (no hivetype needed)
 
 ### Whips
   - Fully matured whips attack without infestation
+  - Increased turning speed before moving
   - Added Bile Splash Ability
     - Available without any hivetype or upgrade
-    - Splash nearby enemies with bile (3 tres, 10 sec cooldown)
+    - Splash nearby enemies with bile (2 tres, 10 sec cooldown)
     - Deals between 1.25-2 full bilebomb damage based on distance
 
 ### Shift
@@ -97,6 +98,9 @@
 ### Focus
   - affects Stab ability now
   - fixed bug which slowed Gore by 57% instead of 33%
+
+### Drifter
+  - Doesnt follow echoed unfinished structures over the entire map anymore
 
 # Marine
 ![alt text](./assets/images/Marine_Banner.webp "Marine")
@@ -163,6 +167,9 @@
 ### HUD
   - New Advanced Option (HUD) "STATUS ICONS"
     - Display status icons even with minimal hud elements.
+
+### Crashes
+  - Flying flamethrowers should in rare cases not crash the server anymore
 
 ### Commander
   - Alien Commander is able to see parasited mines

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,10 @@
   - affects Stab ability now
   - fixed bug which slowed Gore by 57% instead of 33%
 
+### Stab
+  - Stab research cost reduced from 25 to 20 tres
+  - Stab energy cost reduced by 16%
+
 ### Drifter
   - Doesnt follow echoed unfinished structures over the entire map anymore
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,7 @@
   - Stab energy cost reduced by 16%
 
 ### Drifter
+  - Increased mucous area of effect to the same size as enzymes
   - Doesnt follow echoed unfinished structures over the entire map anymore
 
 # Marine

--- a/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanderBrain_Senses.lua
+++ b/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanderBrain_Senses.lua
@@ -1,0 +1,19 @@
+
+local oldCreateMarineComSenses = CreateMarineComSenses
+function CreateMarineComSenses()
+
+
+    local s = oldCreateMarineComSenses()
+
+    s:Add("mainAdvancedPrototypeLab", function(db)
+        local startingLocationId = Shared.GetStringIndex(db.bot.brain:GetStartingTechPoint() or "")
+        local units = GetEntitiesAliveForTeamByLocationWithTechId( "PrototypeLab", db.bot:GetTeamNumber(), startingLocationId, kTechId.AdvancedPrototypeLab )
+        if #units > 0 then
+            return units[1]
+        end
+    end)
+
+  
+    return s
+
+end

--- a/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanerBrain_TechPath.lua
+++ b/src/lua/CommunityBalanceMod/AdvancedPrototypelab/MarineCommanerBrain_TechPath.lua
@@ -1,0 +1,80 @@
+
+local kMarineCommanderTechPath =
+{
+    -- Tier 1 (Early Game)
+    {
+        kTechId.ArmsLab,
+        kTechId.Armor1,
+        kTechId.Armory,
+    },
+
+    -- Tier 2
+    {
+        -- Phase Tech
+        kTechId.Observatory,
+        kTechId.PhaseTech,
+
+        kTechId.Weapons1,
+        kTechId.PhaseGate,
+        kTechId.MinesTech,
+        kTechId.Armor2,
+    },
+
+    -- Tier 3
+    {
+        -- Auxillary stuff
+        kTechId.ShotgunTech,
+        kTechId.Weapons2,
+        kTechId.GrenadeTech,
+    },
+
+    -- Tier 4
+    {
+        kTechId.AdvancedArmoryUpgrade, -- Flamethrower, GL, HMG all unlocked by this upgrade
+        kTechId.PrototypeLab,
+    },
+
+    -- Tier 5
+    {
+        kTechId.JetpackTech,
+        kTechId.UpgradeToAdvancedPrototypeLab, --Balance Mod
+        --kTechId.ExosuitTech, --Balance Mod
+        kTechId.AdvancedMarineSupport, -- Nanoshield, Powersurge, Catpack
+        kTechId.Weapons3,
+        kTechId.Armor3,
+    },
+}
+
+
+local NewGetTechPath = debug.getupvaluex(GetMarineComNextTechStep, "GetTechPath")
+debug.setupvaluex(NewGetTechPath, "kMarineCommanderTechPath", kMarineCommanderTechPath)
+
+debug.setupvaluex(GetMarineComNextTechStep, "GetTechPath", NewGetTechPath)
+
+
+
+local kTechTestReroutes =
+{
+    [kTechId.AdvancedArmoryUpgrade] = kTechId.AdvancedArmory,
+    [kTechId.UpgradeToAdvancedPrototypeLab] = kTechId.AdvancedPrototypeLab --Balance Mod
+}
+
+local kBuildTechIdToSenseMap =
+{
+    [kTechId.ArmsLab]            = "mainArmsLab"           ,
+    [kTechId.Armory]             = "mainArmory"            ,
+    [kTechId.Observatory]        = "mainObservatory"       ,
+    [kTechId.PhaseGate]          = "mainPhaseGate"         ,
+    [kTechId.AdvancedArmory]     = "mainAdvancedArmory"    ,
+    [kTechId.PrototypeLab]       = "mainPrototypeLab"      ,
+    [kTechId.AdvancedPrototypeLab]= "mainAdvancedPrototypeLab", --Balance Mod
+    --[kTechId.RoboticsFactory]    = "hasRoboticsFactoryInBase"   ,
+    --[kTechId.ARCRoboticsFactory] = "hasARCRoboticsFactoryInBase",
+}
+
+local NewGetHasTechForMarineTechPath = debug.getupvaluex(GetMarineComNextTechStep, "GetHasTechForMarineTechPath")
+debug.setupvaluex(NewGetHasTechForMarineTechPath, "kTechTestReroutes", kTechTestReroutes)
+debug.setupvaluex(NewGetHasTechForMarineTechPath, "kBuildTechIdToSenseMap", kBuildTechIdToSenseMap)
+
+
+debug.setupvaluex(GetMarineComNextTechStep, "GetHasTechForMarineTechPath", NewGetHasTechForMarineTechPath)

--- a/src/lua/CommunityBalanceMod/BalanceValueChanges/Balance.lua
+++ b/src/lua/CommunityBalanceMod/BalanceValueChanges/Balance.lua
@@ -5,6 +5,8 @@ kPulseGrenadeDamage = 60 -- vanilla: 50
 kPulseGrenadeEnergyDamageRadius = 6 -- 4
 kDropMineCost = 5 --7
 kWelderDropCost = 2 -- 7
+kStabEnergyCost = 25 --30
+kStabResearchCost = 20 -- 25
 
 kAdvancedMarineSupportResearchCost = 15 -- 20
 kNanoShieldCost = 2 --3
@@ -13,6 +15,7 @@ kNanoShieldCost = 2 --3
 -- Nerfs
 kClusterGrenadeDamageRadius = 8 --10
 kClusterFragmentDamageRadius = 5 -- 6
+
 
 
 

--- a/src/lua/CommunityBalanceMod/BalanceValueChanges/Balance.lua
+++ b/src/lua/CommunityBalanceMod/BalanceValueChanges/Balance.lua
@@ -11,6 +11,7 @@ kStabResearchCost = 20 -- 25
 kAdvancedMarineSupportResearchCost = 15 -- 20
 kNanoShieldCost = 2 --3
 
+kMucousMembraneAbilityRadius = 6.5 -- 5
 
 -- Nerfs
 kClusterGrenadeDamageRadius = 8 --10

--- a/src/lua/CommunityBalanceMod/CombinedProtoFortress/TechTreeConstants.lua
+++ b/src/lua/CommunityBalanceMod/CombinedProtoFortress/TechTreeConstants.lua
@@ -29,6 +29,7 @@ local newTechIds = {
     'HallucinateVeil',
     'HallucinateEgg',
     'HallucinateCloning',
+    'HallucinateRandom',
 
 }
 

--- a/src/lua/CommunityBalanceMod/DrifterStopAtEcho/Drifter.lua
+++ b/src/lua/CommunityBalanceMod/DrifterStopAtEcho/Drifter.lua
@@ -1,0 +1,39 @@
+
+function Drifter:ProcessGrowOrder(moveSpeed, deltaTime)
+
+    local currentOrder = self:GetCurrentOrder()
+
+    if currentOrder ~= nil then
+
+        local target = Shared.GetEntity(currentOrder:GetParam())
+
+        if not target or target:GetIsBuilt() or not target:GetIsAlive() then
+            self:CompletedCurrentOrder()
+
+
+        -- Balance mod
+        elseif target.GetIsTeleporting ~= nil and target:GetIsTeleporting() then 
+            self:CompletedCurrentOrder()
+        else
+
+            local targetPos = target:GetOrigin()
+            local toTarget = targetPos - self:GetOrigin()
+            -- Continuously turn towards the target. But don't mess with path finding movement if it was done.
+
+            if (toTarget):GetLength() > 3 then
+                self:MoveToTarget(PhysicsMask.AIMovement, targetPos, moveSpeed, deltaTime)
+            else
+
+                if toTarget then
+                    self:SmoothTurn(deltaTime, GetNormalizedVector(toTarget), 0)
+                end
+
+                target:RefreshDrifterConstruct()
+                self.constructing = true
+            end
+
+        end
+
+    end
+
+end

--- a/src/lua/CommunityBalanceMod/FileHooks.lua
+++ b/src/lua/CommunityBalanceMod/FileHooks.lua
@@ -342,6 +342,11 @@ Loader_SetupFilehook( "lua/MAC.lua", "post", folder )
 -- babbler_ball.surface_shader
 
 
+-- == Drifter doesnt follow echo ==
+folder = "DrifterStopAtEcho"
+Loader_SetupFilehook( "lua/Drifter.lua", "post", folder )
+
+
 
 
 

--- a/src/lua/CommunityBalanceMod/FileHooks.lua
+++ b/src/lua/CommunityBalanceMod/FileHooks.lua
@@ -212,6 +212,8 @@ Loader_SetupFilehook("lua/TechTreeButtons.lua", "post", folder)
 -- TechTreeConstants.lua 
 -- TechTree.lua 
 -- TeamInfo.lua
+Loader_SetupFilehook("lua/bots/MarineCommanderBrain_Senses.lua", "post", folder)
+Loader_SetupFilehook("lua/bots/MarineCommanerBrain_TechPath.lua", "post", folder)
 Loader_SetupFilehook("lua/Balance.lua", "post", folder)
 Loader_SetupFilehook("lua/TechData.lua", "post", folder)
 Loader_SetupFilehook("lua/ServerStats.lua", "post", folder)

--- a/src/lua/CommunityBalanceMod/FileHooks.lua
+++ b/src/lua/CommunityBalanceMod/FileHooks.lua
@@ -320,7 +320,7 @@ Loader_SetupFilehook( "lua/UmbraMixin.lua", "post", folder ) -- finetunes umbra 
 Loader_SetupFilehook( "lua/Weapons/BoneShield.lua", "post", folder ) -- fixed bone shield triggering cooldown when already on cooldown
 Loader_SetupFilehook( "lua/Alien_Client.lua", "post", folder )
 -- pulse_gre_elec.surface_shader    increased visibility on model
-
+Loader_SetupFilehook( "lua/Weapons/Marine/Flamethrower.lua", "post", folder ) -- fixes FT errors when JP rushing a hive?
 
 -- == Catpack affects welding ==
 folder = "CatpackBuffs"

--- a/src/lua/CommunityBalanceMod/FortressPvE/AlienTeam.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/AlienTeam.lua
@@ -65,6 +65,7 @@ function AlienTeam:InitTechTree()
     self.techTree:AddTargetedActivation(kTechId.MucousMembrane,   kTechId.CragHive,      kTechId.None)
     --self.techTree:AddTargetedActivation(kTechId.Storm,            kTechId.ShiftHive,       kTechId.None)
     self.techTree:AddActivation(kTechId.DestroyHallucination)
+    self.techTree:AddActivation(kTechId.HallucinateRandom)
     self.techTree:AddTargetedActivation(kTechId.HallucinateCloning)
 
     -- Cyst passives

--- a/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
@@ -3,8 +3,8 @@
 -- FortressPvE
 kFortressUpgradeCost = 24
 kFortressResearchTime = 25
-kFortressAbilityCooldown = 10
-kFortressAbilityCost = 3
+kFortressAbilityCooldown = 15
+kFortressAbilityCost = 2
 kCragCost = 8
 kShiftCost = 8
 kShadeCost = 8
@@ -18,7 +18,7 @@ kHallucinationLifeTime = 0.1 -- ignored, last indefinitely
 
 kStormCloudDuration = 9.5
 
-kWhipAbilityCost = 3
+kWhipAbilityCost = 2
 kWhipAbilityCooldown = 10
 
 kHallucinateCloningCost = 0

--- a/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Balance.lua
@@ -14,7 +14,7 @@ kWhipCost = 8
 kCragUmbra = 5
 
 kMaxHallucinations = 6
-kHallucinationLifeTime = 600
+kHallucinationLifeTime = 0.1 -- ignored, last indefinitely
 
 kStormCloudDuration = 9.5
 
@@ -22,4 +22,6 @@ kWhipAbilityCost = 3
 kWhipAbilityCooldown = 10
 
 kHallucinateCloningCost = 0
-kHallucinateCloningCooldown = 1
+kHallucinateCloningCooldown = 1.5
+kHallucinateRandomCost = 0
+kHallucinateRandomCooldown = 1.5

--- a/src/lua/CommunityBalanceMod/FortressPvE/BalanceHealth.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/BalanceHealth.lua
@@ -26,20 +26,20 @@ kMatureShiftArmor = 120
 
 -- we cant use the constants, since MDS changes them
 
-kFortressCragHealth = 480 * 3 + 160 * 4
-kFortressCragArmor = 160
-kFortressMatureCragHealth = 560 * 3 + 272 * 4
-kFortressMatureCragArmor = 272 
+kFortressCragHealth = 480 * 3 + 160 * 3
+kFortressCragArmor = 160 * 1.5
+kFortressMatureCragHealth = 560 * 3 + 272 * 3
+kFortressMatureCragArmor = 272 * 1.5
         
-kFortressWhipHealth = 650 * 3 + 175 * 4
-kFortressWhipArmor = 175
-kFortressMatureWhipHealth = 720 * 3  + 240 * 4
-kFortressMatureWhipArmor = 240
+kFortressWhipHealth = 650 * 3 + 175 * 3
+kFortressWhipArmor = 175 * 1.5
+kFortressMatureWhipHealth = 720 * 3  + 240 * 3
+kFortressMatureWhipArmor = 240 * 1.5
 
-kFortressShiftHealth = 600 * 3 + 60 * 4
-kFortressShiftArmor = 60
-kFortressMatureShiftHealth = 880 * 3 + 120 * 4
-kFortressMatureShiftArmor = 120 
+kFortressShiftHealth = 600 * 3 + 60 * 3
+kFortressShiftArmor = 60 * 1.5
+kFortressMatureShiftHealth = 880 * 3 + 120 * 3
+kFortressMatureShiftArmor = 120 * 1.5
 
 kFortressShadeHealth = 600 * 3
 kFortressShadeArmor = 0

--- a/src/lua/CommunityBalanceMod/FortressPvE/BalanceHealth.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/BalanceHealth.lua
@@ -43,4 +43,5 @@ kFortressShadeArmor = 0 * 3
 kFortressMatureShadeHealth = 1200 * 3
 kFortressMatureShadeArmor = 0 * 3
 
+kBalanceOffInfestationHurtPercentPerSecondFortress = 0.02 / 3
 

--- a/src/lua/CommunityBalanceMod/FortressPvE/BalanceHealth.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/BalanceHealth.lua
@@ -1,47 +1,50 @@
 
 
 
--- Fortress PvE
-kCragHealth = 440
-kCragArmor = 140
-kMatureCragHealth = 510
-kMatureCragArmor = 250
 
-kWhipHealth = 600
-kWhipArmor = 160
-kMatureWhipHealth = 660
-kMatureWhipArmor = 220
+--[[
+kCragHealth = 480    
+kCragArmor = 160
+kMatureCragHealth = 560    
+kMatureCragArmor = 272
 
-kShiftHealth = 550
-kShiftArmor = 60
-kMatureShiftHealth = 810
-kMatureShiftArmor = 110
+kWhipHealth = 650    
+kWhipArmor = 175
+kMatureWhipHealth = 720    
+kMatureWhipArmor = 240
 
-kShadeHealth = 550
+kShadeHealth = 600    
 kShadeArmor = 0
-kMatureShadeHealth = 1100
+kMatureShadeHealth = 1200
 kMatureShadeArmor = 0
 
+kShiftHealth = 600    
+kShiftArmor = 60
+kMatureShiftHealth = 880    
+kMatureShiftArmor = 120
+]]
 
-kFortressCragHealth = 480 * 3 
-kFortressCragArmor = 160 * 3 
-kFortressMatureCragHealth = 560 * 3 
-kFortressMatureCragArmor = 272 * 3 
+-- we cant use the constants, since MDS changes them
+
+kFortressCragHealth = 480 * 3 + 160 * 4
+kFortressCragArmor = 160
+kFortressMatureCragHealth = 560 * 3 + 272 * 4
+kFortressMatureCragArmor = 272 
         
-kFortressWhipHealth = 650 * 3 
-kFortressWhipArmor = 175 * 3 
-kFortressMatureWhipHealth = 720 * 3 
-kFortressMatureWhipArmor = 240 * 3 
+kFortressWhipHealth = 650 * 3 + 175 * 4
+kFortressWhipArmor = 175
+kFortressMatureWhipHealth = 720 * 3  + 240 * 4
+kFortressMatureWhipArmor = 240
 
-kFortressShiftHealth = 600 * 3 
-kFortressShiftArmor = 60* 3 
-kFortressMatureShiftHealth = 880 * 3 
-kFortressMatureShiftArmor = 120 * 3 
+kFortressShiftHealth = 600 * 3 + 60 * 4
+kFortressShiftArmor = 60
+kFortressMatureShiftHealth = 880 * 3 + 120 * 4
+kFortressMatureShiftArmor = 120 
 
 kFortressShadeHealth = 600 * 3
-kFortressShadeArmor = 0 * 3
+kFortressShadeArmor = 0
 kFortressMatureShadeHealth = 1200 * 3
-kFortressMatureShadeArmor = 0 * 3
+kFortressMatureShadeArmor = 0
 
 kBalanceOffInfestationHurtPercentPerSecondFortress = 0.02 / 3
 

--- a/src/lua/CommunityBalanceMod/FortressPvE/BalanceMisc.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/BalanceMisc.lua
@@ -1,3 +1,4 @@
-kHallucinationHealthFraction = 0.4 --0.20
-kHallucinationArmorFraction = 0.1
-kHallucinationMaxHealth = 250 --700
+kHallucinationHealthFraction = 1.0 --0.4
+kHallucinationArmorFraction = 1.0 --0.1
+kHallucinationMaxHealth = 2000 --700
+kHallucinationDamageMulti = 3.66 -- hallucinations take more damage

--- a/src/lua/CommunityBalanceMod/FortressPvE/Crag.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Crag.lua
@@ -17,6 +17,15 @@ function Crag:OnCreate()
 end
 
 
+function Crag:GetOffInfestationHurtPercentPerSecond()
+
+    if self:GetTechId() == kTechId.FortressCrag then 
+        return kBalanceOffInfestationHurtPercentPerSecondFortress
+    end
+
+    return kBalanceOffInfestationHurtPercentPerSecond
+end
+
 
 -- new
 function Crag:GetUmbraTargets()

--- a/src/lua/CommunityBalanceMod/FortressPvE/Crag.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Crag.lua
@@ -108,7 +108,7 @@ function Crag:GetTechAllowed(techId, techNode, player)
 
     -- dont allow normal crags to use the new fortress ability.
     if techId == kTechId.FortressCragAbility then
-        allowed = self:GetTechId() == kTechId.FortressCrag and GetHasTech(self, kTechId.CragHive)
+        allowed = allowed and ( self:GetTechId() == kTechId.FortressCrag ) and GetHasTech(self, kTechId.CragHive)
     end
 
     -- Healwave craghive requirement got removed

--- a/src/lua/CommunityBalanceMod/FortressPvE/Hallucination.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Hallucination.lua
@@ -542,7 +542,7 @@ function Hallucination:PerformActivation(techId, position, normal, commander)
             return false, true
         end
 		
-        local entities = GetEntitiesWithMixinForTeamWithinRange("Live", self:GetTeamNumber(), position, 1.5)
+        local entities = GetEntitiesWithMixinForTeamWithinRange("Live", self:GetTeamNumber(), position, 2)
 		
         local CheckFunc = function(entity)
             return techIdToHallucinateId[entity:GetTechId()] and true or entity:isa("Hallucination") or false

--- a/src/lua/CommunityBalanceMod/FortressPvE/Locale.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Locale.lua
@@ -37,4 +37,7 @@ if Client then
 	
     Locale.substitutions["HALLUCINATE_CLONING"] = "Hallucination Cloning"
     Locale.substitutions["HALLUCINATE_CLONING_TOOLTIP"] = "Change Hallucination into a copy of a valid target"
+    
+    Locale.substitutions["HALLUCINATE_RANDOM"] = "Random Hallucination"
+    Locale.substitutions["HALLUCINATE_RANDOM_TOOLTIP"] = "Change Hallucination into a random one"
 end

--- a/src/lua/CommunityBalanceMod/FortressPvE/ServerStats.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/ServerStats.lua
@@ -6,6 +6,12 @@ function StatsUI_AddTechStat(teamNumber, techId, built, destroyed, recycled)
 		and techId ~= kTechId.UpgradeToFortressShift
 		and techId ~= kTechId.UpgradeToFortressShade
 		and techId ~= kTechId.UpgradeToFortressWhip
+		and techId ~= kTechId.Crag
+		and techId ~= kTechId.Shift
+		and techId ~= kTechId.Shade
+		and techId ~= kTechId.Whip
+		and techId ~= kTechId.RoboticsFactory
+		and techId ~= kTechId.Armory
 		then
 		OldStatsUI_AddTechStat(teamNumber, techId, built, destroyed, recycled)
 	end
@@ -26,4 +32,30 @@ function StatsUI_AddBuildingStat(teamNumber, techId, lost)
 	end
 
 	OldStatsUI_AddBuildingStat(teamNumber, techId, lost)
+end
+
+
+
+local techLogBuildings = set {
+	"ArmsLab",
+	"PrototypeLab",
+	"Observatory",
+	"InfantryPortal",
+	"CommandStation",
+	"Veil",
+	"Shell",
+	"Spur",
+	"Hive",
+
+	"Armory",
+	"RoboticsFactory",
+	"Whip",
+	"Shade",
+	"Shift",
+	"Crag",
+
+}
+
+function StatsUI_GetBuildingLogged(structureName)
+	return techLogBuildings[structureName]
 end

--- a/src/lua/CommunityBalanceMod/FortressPvE/Shade.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Shade.lua
@@ -96,7 +96,7 @@ function Shade:GetTechAllowed(techId, techNode, player)
 
     -- dont allow normal Shades to use the new fortress ability
     if techId == kTechId.ShadeHallucination then
-        allowed = self:GetTechId() == kTechId.FortressShade and GetHasTech(self, kTechId.ShadeHive)
+        allowed = allowed and ( self:GetTechId() == kTechId.FortressShade ) and GetHasTech(self, kTechId.ShadeHive)
     end
 
     -- ShadeInk Shadehive requirement got removed

--- a/src/lua/CommunityBalanceMod/FortressPvE/Shade.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Shade.lua
@@ -17,6 +17,16 @@ function Shade:OnCreate()
 end
 
 
+
+function Shade:GetOffInfestationHurtPercentPerSecond()
+
+    if self:GetTechId() == kTechId.FortressShade then 
+        return kBalanceOffInfestationHurtPercentPerSecondFortress
+    end
+
+    return kBalanceOffInfestationHurtPercentPerSecond
+end
+
 function Shade:GetMaxSpeed()
 
     if self:GetTechId() == kTechId.FortressShade then

--- a/src/lua/CommunityBalanceMod/FortressPvE/Shift.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Shift.lua
@@ -21,6 +21,17 @@ function Shift:OnCreate()
 end
 
 
+function Shift:GetOffInfestationHurtPercentPerSecond()
+
+    if self:GetTechId() == kTechId.FortressShift then 
+        return kBalanceOffInfestationHurtPercentPerSecondFortress
+    end
+
+    return kBalanceOffInfestationHurtPercentPerSecond
+end
+
+
+
 function Shift:GetMaxSpeed()
 
     if self:GetTechId() == kTechId.FortressShift then

--- a/src/lua/CommunityBalanceMod/FortressPvE/Shift.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Shift.lua
@@ -279,7 +279,7 @@ function Shift:GetTechAllowed(techId, techNode, player)
     
             allowed = allowed and not GetHasTech(self, kTechId.FortressShift) and not  GetIsTechResearching(self, techId)
         elseif techId == kTechId.FortressShiftAbility then
-            allowed = self:GetTechId() == kTechId.FortressShift and GetHasTech(self, kTechId.ShiftHive)
+            allowed = allowed and ( self:GetTechId() == kTechId.FortressShift ) and GetHasTech(self, kTechId.ShiftHive)
         else
 
 

--- a/src/lua/CommunityBalanceMod/FortressPvE/TechData.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/TechData.lua
@@ -1,10 +1,8 @@
+local removeTechDataValue = "BalanceModRemoveTechData"
 
-local oldBuildTechData = BuildTechData
-function BuildTechData()
-    
-    local techData = oldBuildTechData()    
-
-        table.insert(techData, { 
+local function GetTechToAdd()
+    return {
+        { 
             [kTechDataId] = kTechId.FortressCrag,
             [kTechDataBioMass] = kCragBiomass,
             [kTechDataSupply] = kCragSupply,
@@ -22,10 +20,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_CRAG_TOOLTIP", 
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 1.15, 
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressCrag,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -34,20 +32,20 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_CRAG_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_CRAG_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true,
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressCragAbility,
             [kTechDataCooldown] = kFortressAbilityCooldown, 
             [kTechDataDisplayName] = "FORTRESS_CRAG_ABILITY", 
             [kTechDataCostKey] = kFortressAbilityCost,
             [kTechDataTooltipInfo] = "FORTRESS_CRAG_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressShift,
             [kTechDataBioMass] = kShiftBiomass,
             [kTechDataSupply] = kShiftSupply,
@@ -68,10 +66,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_SHIFT_TOOLTIP", 
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 1.3,
-        })
+        },
 
 
-        table.insert(techData, {  
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressShift,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -80,20 +78,20 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_SHIFT_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_SHIFT_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true,
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressShiftAbility,
             [kTechDataCooldown] = kFortressAbilityCooldown, 
             [kTechDataDisplayName] = "FORTRESS_SHIFT_ABILITY", 
             [kTechDataCostKey] = kFortressAbilityCost,
             [kTechDataTooltipInfo] = "FORTRESS_SHIFT_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressShade,
             [kTechDataBioMass] = kShadeBiomass,
             [kTechDataSupply] = kShadeSupply,
@@ -112,10 +110,10 @@ function BuildTechData()
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 1.25,
             [kTechDataMaxExtents] = Vector(1, 1.3, .4),
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressShade,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -124,13 +122,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_SHADE_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_SHADE_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true, 
-        })
+        },
 
 
-       
-
-
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressWhip,
             [kTechDataBioMass] = kWhipBiomass,
             [kTechDataSupply] = kWhipSupply,
@@ -149,10 +144,10 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_WHIP_TOOLTIP", 
             [kTechDataGrows] = false, 
             [kTechDataObstacleRadius] = 0.85,
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.UpgradeToFortressWhip,
             [kTechDataCostKey] = kFortressUpgradeCost,
             [kTechIDShowEnables] = false,
@@ -161,30 +156,30 @@ function BuildTechData()
             [kTechDataTooltipInfo] = "FORTRESS_WHIP_UPGRADE_TOOLTIP",
             [kTechDataResearchName] = "FORTRESS_WHIP_UPGRADE_RESEARCHNAME",
             [kTechDataOneAtATime] = true, 
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.FortressWhipAbility,
             [kTechDataCooldown] = kFortressAbilityCooldown, 
             [kTechDataDisplayName] = "FORTRESS_WHIP_ABILITY", 
             [kTechDataCostKey] = kFortressAbilityCost,
             [kTechDataTooltipInfo] = "FORTRESS_WHIP_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.WhipAbility,
             [kTechDataCooldown] = kWhipAbilityCooldown, 
             [kTechDataDisplayName] = "WHIP_ABILITY", 
             [kTechDataCostKey] = kWhipAbilityCost,
             [kTechDataTooltipInfo] = "WHIP_ABILITY_TOOLTIP", 
             [kTechDataOneAtATime] = true,  
-        })
+        },
 
 
-        table.insert(techData, { 
+        { 
             [kTechDataId] = kTechId.ShadeHallucination,
             [kTechDataMapName] = ShadeHallucination.kMapName,
             [kTechDataCooldown] = kFortressAbilityCooldown,
@@ -198,9 +193,10 @@ function BuildTechData()
             [kTechDataAllowStacking] = true,
             [kTechDataOneAtATime] = true,
             [kTechDataModel] = BoneWall.kModelName,
-        })
-    
-        table.insert(techData, {
+        },
+
+
+        {
             [kTechDataId] = kTechId.HallucinateShell,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -208,9 +204,12 @@ function BuildTechData()
             [kTechDataModel] = Shell.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
-            
-        table.insert(techData, {
+            [kTechDataMaxHealth] = kMatureShellHealth,
+            [kTechDataMaxArmor] = kMatureShellArmor,
+        },
+
+        
+        {
             [kTechDataId] = kTechId.HallucinateSpur,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -218,9 +217,12 @@ function BuildTechData()
             [kTechDataModel] = Spur.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
-            
-        table.insert(techData, {
+            [kTechDataMaxHealth] = kMatureSpurHealth,
+            [kTechDataMaxArmor] = kMatureSpurArmor,            
+        },
+
+
+        {
             [kTechDataId] = kTechId.HallucinateVeil,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -228,9 +230,12 @@ function BuildTechData()
             [kTechDataModel] = Veil.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
-        
-        table.insert(techData, {
+            [kTechDataMaxHealth] = kMatureVeilHealth,
+            [kTechDataMaxArmor] = kMatureVeilArmor,
+        },
+
+
+        {
             [kTechDataId] = kTechId.HallucinateEgg,
             [kTechDataRequiresMature] = false,
             [kTechDataRequiresInfestation] = true,
@@ -238,17 +243,140 @@ function BuildTechData()
             [kTechDataModel] = Egg.kModelName,
             [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
             [kTechDataCostKey] = kHallucinateShiftEnergyCost,
-        })
+            [kTechDataMaxHealth] = kEggHealth,
+            [kTechDataMaxArmor] = kEggArmor,
+        },
 
-        table.insert(techData, {
+
+        {
             [kTechDataId] = kTechId.HallucinateCloning,
             [kTechDataDisplayName] = "HALLUCINATE_CLONING",
             [kTechDataTooltipInfo] = "HALLUCINATE_CLONING_TOOLTIP",
             [kTechDataCostKey] = kHallucinateCloningCost,
             [kTechDataCooldown] = kHallucinateCloningCooldown,
             [kTechDataOrderSound] = AlienCommander.kBuildStructureSound,
-        })
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateRandom,
+            [kTechDataDisplayName] = "HALLUCINATE_RANDOM",
+            [kTechDataTooltipInfo] = "HALLUCINATE_RANDOM_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateRandomCost,
+            [kTechDataCooldown] = kHallucinateRandomCooldown,
+            [kTechDataOrderSound] = AlienCommander.kBuildStructureSound,
+        },       
+
+
+        -- Add new values for removed tech
+        {
+            [kTechDataId] = kTechId.HallucinateWhip,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_WHIP",
+            [kTechDataModel] = Whip.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_WHIP_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateWhipEnergyCost,
+            [kTechDataMaxHealth] = kMatureWhipHealth,
+            [kTechDataMaxArmor] = kMatureWhipArmor,
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateShade,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_SHADE",
+            [kTechDataModel] = Shade.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_SHADE_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateShadeEnergyCost,
+            [kTechDataMaxHealth] = kMatureShadeHealth,
+            [kTechDataMaxArmor] = kMatureShadeArmor,
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateCrag,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_CRAG",
+            [kTechDataModel] = Crag.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_CRAG_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateCragEnergyCost,
+            [kTechDataMaxHealth] = kMatureCragHealth,
+            [kTechDataMaxArmor] = kMatureCragArmor,
+        },
+
+
+        {
+            [kTechDataId] = kTechId.HallucinateShift,
+            [kTechDataRequiresMature] = true,
+            [kTechDataRequiresInfestation] = true,
+            [kTechDataDisplayName] = "HALLUCINATE_SHIFT",
+            [kTechDataModel] = Shift.kModelName,
+            [kTechDataTooltipInfo] = "HALLUCINATE_SHIFT_TOOLTIP",
+            [kTechDataCostKey] = kHallucinateShiftEnergyCost,
+            [kTechDataMaxHealth] = kMatureShiftHealth,
+            [kTechDataMaxArmor] = kMatureShiftArmor,
+        },
+    }
+end
+
+local function GetTechToChange()
+    return {}
+end
+
+local function GetTechToRemove() 
+    return {
+        [kTechId.HallucinateWhip] = true,
+        [kTechId.HallucinateShade] = true,
+        [kTechId.HallucinateCrag] = true,
+        [kTechId.HallucinateShift] = true,
+    }
+end
+
+local function TechDataChanges(techData)
+    -- Handle changes / removes
+    local techToChange = GetTechToChange()
+    local techToRemove = GetTechToRemove()
+    local indexToRemove = {}
+
+    for techIndex,record in ipairs(techData) do
+        local techDataId = record[kTechDataId]
+
+        if techToRemove[techDataId] then
+            table.insert(indexToRemove, techIndex)
+        elseif techToChange[techDataId] then
+            for index, value in pairs(techToChange[techDataId]) do
+                if value == removeTechDataValue then
+                    techData[techIndex][index] = nil
+                else
+                    techData[techIndex][index] = value
+                end
+            end
+        end
+    end
+
+    -- Remove tech
+    local offset = 0
+    for _,idx in ipairs(indexToRemove) do
+        table.remove(techData, idx - offset)
+        offset = offset + 1
+    end
+
+    -- Add new tech
+    local techToAdd = GetTechToAdd()
+    for _,v in ipairs(techToAdd) do
+        table.insert(techData, v)
+    end
+end
+
+local oldBuildTechData = BuildTechData
+function BuildTechData()
+    
+    local techData = oldBuildTechData()    
+        
+    TechDataChanges(techData)
     
     return techData
 end
-

--- a/src/lua/CommunityBalanceMod/FortressPvE/TechTreeButtons.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/TechTreeButtons.lua
@@ -25,6 +25,7 @@ local toAdd = {
     {kTechId.HallucinateVeil, 23}, 
     {kTechId.HallucinateEgg, 34}, 
     {kTechId.HallucinateCloning, 123}, 
+    {kTechId.HallucinateRandom, 120}, 
     
 }
 

--- a/src/lua/CommunityBalanceMod/FortressPvE/Whip_Server.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Whip_Server.lua
@@ -168,3 +168,48 @@ function Whip:OnMaturityComplete()
     end
     self:GiveUpgrade(kTechId.WhipBombard)
 end
+
+
+
+Whip.kTurnSpeed = 2 * math.pi
+function Whip:GetTurnSpeedOverride()
+    return self.kTurnSpeed
+end
+
+
+function Whip:Root()
+
+    StartSoundEffectOnEntity(Whip.kRootedSound, self)
+
+    self:AttackerMoved() -- reset target sel
+
+    self.rooted = true
+
+    if self.frenzy then 
+        self:SetBlockTime(0.2) 
+    else
+         self:SetBlockTime(0.5)
+    end
+
+    self:EndAttack()
+    self.targetId = Entity.invalidId
+
+    return true
+
+end
+
+function Whip:Unroot()
+
+    StartSoundEffectOnEntity(Whip.kUnrootSound, self)
+
+    self.rooted = false
+    if self.frenzy then 
+        self:SetBlockTime(0.2) 
+    else
+         self:SetBlockTime(0.5)
+    end
+    self:EndAttack()
+
+    return true
+
+end

--- a/src/lua/CommunityBalanceMod/MDSmarines/BalanceHealth.lua
+++ b/src/lua/CommunityBalanceMod/MDSmarines/BalanceHealth.lua
@@ -77,8 +77,6 @@ kMatureInfestedTunnelEntranceHealth = 1610    kMatureInfestedTunnelEntranceArmor
 kTunnelStartingHealthScalar = 0.18 --Percentage of kTunnelEntranceHealth & kTunnelEntranceArmor newly placed Tunnel has
 
 
-
--- Fortress PvE
 kCragHealth = 440
 kCragArmor = 140
 kMatureCragHealth = 510

--- a/src/lua/CommunityBalanceMod/MDSmarines/BalanceHealth.lua
+++ b/src/lua/CommunityBalanceMod/MDSmarines/BalanceHealth.lua
@@ -10,9 +10,9 @@ kMatureBabblerEggHealth = 360
 -- kHiveHealth = 4000    kHiveArmor = 750    kHivePointValue = 30
 kHiveHealth = 4600    kHiveArmor = 860
 
--- 25% instead of 15%
+-- 20% instead of 15%
 -- kMatureHiveHealth = 6000 kMatureHiveArmor = 1400
-kMatureHiveHealth = 7500 kMatureHiveArmor = 1750
+kMatureHiveHealth = 7000 kMatureHiveArmor = 1750
 
         
 -- kHarvesterHealth = 2000 kHarvesterArmor = 200 kHarvesterPointValue = 15
@@ -78,4 +78,23 @@ kTunnelStartingHealthScalar = 0.18 --Percentage of kTunnelEntranceHealth & kTunn
 
 
 
--- hives, crag, whip, shift, shades, crags are changed at fortress pve
+-- Fortress PvE
+kCragHealth = 440
+kCragArmor = 140
+kMatureCragHealth = 510
+kMatureCragArmor = 250
+
+kWhipHealth = 600
+kWhipArmor = 160
+kMatureWhipHealth = 660
+kMatureWhipArmor = 220
+
+kShiftHealth = 550
+kShiftArmor = 60
+kMatureShiftHealth = 810
+kMatureShiftArmor = 110
+
+kShadeHealth = 550
+kShadeArmor = 0
+kMatureShadeHealth = 1100
+kMatureShadeArmor = 0

--- a/src/lua/CommunityBalanceMod/MDSmarines/HitSounds.lua
+++ b/src/lua/CommunityBalanceMod/MDSmarines/HitSounds.lua
@@ -99,7 +99,7 @@ if Server then
 
 
             local target = Shared.GetEntity(hit.target) -- Balance mod adds target for DamageTypes.lua
-            Log("hitsound %s", NS2Gamerules_GetUpgradedDamageScalar( attacker, hit.weapon, target ) )
+            --Log("hitsound %s", NS2Gamerules_GetUpgradedDamageScalar( attacker, hit.weapon, target ) )
             local chargeAmount = ( ( hit.overkill / NS2Gamerules_GetUpgradedDamageScalar( attacker, hit.weapon, target ) ) - kRailgunDamage ) / kRailgunChargeDamage
             if kHitSoundHigh <= chargeAmount then
                 sound = 3

--- a/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
+++ b/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
@@ -37,6 +37,7 @@ on the official discord to let me and the team know what you think! Below are th
   - Camouflage cloaks 100% at medium-far distance (buff)
   - Swapping upgrades cost less pres (eg. Vampirism->Regeneration) (buff)
   - Focus works with stab and gore (buff)
+  - Stab research and energy cost reduced (buff)
   - Crag/Shift/Shade/Whip cost reduction (8 from 13), 20% less HP, 25% faster speed (buff)
   - New fortress upgrade for them (24 pres), 300% HP, 25% slower speed, unlocks new abilities (new)
   - Fully matured whips attack without infestation (buff)
@@ -49,6 +50,10 @@ on the official discord to let me and the team know what you think! Below are th
 ## ALIEN
 ### Hives
   - Reduced the additional 10% HP buff for maturity hives to 5%
+
+### Stab
+  - Stab research cost reduced from 25 to 20 tres
+  - Stab energy cost reduced by 16%
 
 ### Fortress Shade
   - Hallucinations time duration removed
@@ -155,6 +160,10 @@ on the official discord to let me and the team know what you think! Below are th
 ### Focus
   - affects Stab ability now
   - fixed bug which slowed Gore by 57% instead of 33%
+
+### Stab
+  - Stab research cost reduced from 25 to 20 tres
+  - Stab energy cost reduced by 16%
 
 ### Crag/Shift/Shade/Whip
   - Reduced cost to 8 tres from 13 tres

--- a/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
+++ b/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
@@ -46,10 +46,10 @@ on the official discord to let me and the team know what you think! Below are th
   - Shells/Veils/Spurs are able to selfheal/selfcloak or move (buff)
   - Drifter hallucination ability replaced with Cloaking Haze ability (server performance)
 
-# Changes between Revision 2.0.3 and 2.0.2: (2023/12/24)
+# Changes between Revision 2.0.3 and 2.0.2: (2023/12/??)
 ## ALIEN
 ### Hives
-  - Reduced the additional 10% HP buff for maturity hives to 5%
+  - Reduced the additional 10% HP buff for full maturity hives to 5%
 
 ### Stab
   - Stab research cost reduced from 25 to 20 tres
@@ -58,7 +58,7 @@ on the official discord to let me and the team know what you think! Below are th
 ### Fortress Shade
   - Hallucinations time duration removed
   - Able to transform into a random different structure
-  - Added HP bars on hallucinations
+  - Added HP bars to hallucinations
 
 ### Whips
   - Increased turning speed before moving
@@ -66,13 +66,14 @@ on the official discord to let me and the team know what you think! Below are th
   - Reduced the cost of bile splash from 3 to 2 tres
 
 ### Fortress Structures
-  - Converted 66% of their armor into HP (huge nerf to healing)
+  - Converted 50% of their armor into HP (nerf to healing)
   - Increased cooldown for all fortress abilities from 10 to 15 seconds
-  - reduced the cost of all fortress abilities from 3 to 2 tres
+  - Reduced the cost of all fortress abilities from 3 to 2 tres
   - Fixed a bug which allowed abilities to being cast while under fire
   - No longer take 3x the damage off infestation in comparison to normal structures
 
 ### Drifter
+  - Increased mucous area of effect to the same size as enzymes
   - Doesnt follow echoed unfinished structures over the entire map anymore
   
 ## MARINE

--- a/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
+++ b/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
@@ -43,7 +43,7 @@ on the official discord to let me and the team know what you think! Below are th
   - Reduced shift energy gain by 50% (nerf)
   - Hydras and Bilemine cost 30% less energy (buff)
   - Shells/Veils/Spurs are able to selfheal/selfcloak or move (buff)
-  - Drifter hallucination ability replaced with cloak cloud ability (server performance)
+  - Drifter hallucination ability replaced with Cloaking Haze ability (server performance)
 
 # Changes between Revision 2.0.2 and 2.0.1: (2023/11/28)
 ## ALIEN
@@ -187,7 +187,7 @@ on the official discord to let me and the team know what you think! Below are th
   - Spurs: Moveable (50% movement speed)
   - Shells: Selfheal (1% each healingcycle)
 
-### Cloaking Cloud
+### Cloaking Haze
   - Replaced Hallucination Cloud
   - Cloaks players, eggs and drifters (including those in combat) for up to 5 seconds.
 

--- a/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
+++ b/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
@@ -77,11 +77,11 @@ on the official discord to let me and the team know what you think! Below are th
 
 
 
-#Changes between Revision 2.0.2 and vanilla:
+#Changes between Revision 2.0.3 and vanilla:
 ## MARINE
 ### Structure Damage Rework
 - Buffed all Alien Structures HP by 15%
-  - Hives receive an additional HP buff of 5% at full maturity for a total of +17%
+  - Hives receive an additional HP buff of 5% at full maturity for a total of +20%
 - Buffed Arc Damage by 15%
 - Buffed Gorge Structure Healing by 15%
 - Every weapon upgrade does +20% structure damage (instead of + 10%)
@@ -169,9 +169,9 @@ on the official discord to let me and the team know what you think! Below are th
   - Cannot be echo'd
   - Restricted to max 1 of each kind
   - Are able to use ink, echo and healwave without a hivetype
-  - Access to a new ability with the corresponding hive type (3 tres, 10 sec cooldown)
+  - Access to a new ability with the corresponding hive type (2 tres, 15 sec cooldown)
     - Umbra(Crag): Cast Umbra 5 seconds on all Structures in healrange
-    - Hallucinations(Shade): Create 6 moveable hallucination Structures (whip or shade likelier) for 120 seconds
+    - Hallucinations(Shade): Create 6 moveable hallucination Structures
     - Stormcloud(Shift): Increase alien movement speed by 20% for 9.5 seconds
     - Frenzy(Whip): 2x attack speed and 2.5x movement speed for 7.5 seconds (no hivetype needed)
 
@@ -179,11 +179,11 @@ on the official discord to let me and the team know what you think! Below are th
   - Fully matured whips attack without infestation
   - Added Bile Splash Ability
     - Available without any hivetype or upgrade
-    - Splash nearby enemies with bile (3 tres, 10 sec cooldown)
+    - Splash nearby enemies with bile (2 tres, 10 sec cooldown)
     - Deals between 1.25-2 full bilebomb damage based on distance
 
 ### Shift
-  - Reduced energy regenerate rate by 66% (changed to 50% with 2.0.2)
+  - Reduced energy regenerate rate by 50%
 
 ### Gorge
   - Hydras and Bilemine cost 30% less energy

--- a/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
+++ b/src/lua/CommunityBalanceMod/Scripts/GUIBetaBalanceChangelogData.lua
@@ -45,35 +45,43 @@ on the official discord to let me and the team know what you think! Below are th
   - Shells/Veils/Spurs are able to selfheal/selfcloak or move (buff)
   - Drifter hallucination ability replaced with Cloaking Haze ability (server performance)
 
-# Changes between Revision 2.0.2 and 2.0.1: (2023/11/28)
+# Changes between Revision 2.0.3 and 2.0.2: (2023/12/24)
 ## ALIEN
-### Crag/Shift/Shade/Whip
-  - Changed fortress PvE upgrade time to 25 seconds, up from 10
-  - Shift energy regen nerf is now 50% the vanilla value (from 66% nerf).
+### Hives
+  - Reduced the additional 10% HP buff for maturity hives to 5%
 
-### Onos
-  - Onos with camouflage will be silent while crouch walking
+### Fortress Shade
+  - Hallucinations time duration removed
+  - Able to transform into a random different structure
+  - Added HP bars on hallucinations
 
-### Heatplating 
-  - Gas grenades now deal reduced damage with heatplating to match other hand grenades
+### Whips
+  - Increased turning speed before moving
+  - Decreased rooting, unrooting time under frenzy
+  - Reduced the cost of bile splash from 3 to 2 tres
 
+### Fortress Structures
+  - Converted 66% of their armor into HP (huge nerf to healing)
+  - Increased cooldown for all fortress abilities from 10 to 15 seconds
+  - reduced the cost of all fortress abilities from 3 to 2 tres
+  - Fixed a bug which allowed abilities to being cast while under fire
+  - No longer take 3x the damage off infestation in comparison to normal structures
+
+### Drifter
+  - Doesnt follow echoed unfinished structures over the entire map anymore
+  
 ## MARINE
-### Advanced Support
-  - Advanced support to 15 tres
-  - Catpacked marines now build and weld 12.5% faster as well
-  - Nanoshield cost reduced to 2 (from 3)
+### Bugfixes 
+  - Flying flamethrowers in rare cases should not crash the server anymore (vanilla bug)
+  - Bot Commanders will research Exos, Weapon 3, Armor 3 again (balance mod bug)
 
-### MACs
-  - Allow MACs to be welded while taking damage
 
-### Hand Grenades
-  - Cluster grenade range and fragment range reduced by 20%
 
 #Changes between Revision 2.0.2 and vanilla:
 ## MARINE
 ### Structure Damage Rework
 - Buffed all Alien Structures HP by 15%
-  - Hives receive an additional HP buff of 10% at full maturity for a total of +25%
+  - Hives receive an additional HP buff of 5% at full maturity for a total of +17%
 - Buffed Arc Damage by 15%
 - Buffed Gorge Structure Healing by 15%
 - Every weapon upgrade does +20% structure damage (instead of + 10%)

--- a/src/lua/CommunityBalanceMod/TwiliteFix/Flamethrower.lua
+++ b/src/lua/CommunityBalanceMod/TwiliteFix/Flamethrower.lua
@@ -1,0 +1,30 @@
+function Flamethrower:CreateFlame(player, position, normal, direction)
+
+    -- create flame entity, but prevent spamming:
+    local nearbyFlames = GetEntitiesForTeamWithinRange("Flame", self:GetTeamNumber(), position, 1.7)
+
+    if (#nearbyFlames == 0) then
+
+        local flame = CreateEntity(Flame.kMapName, position, player:GetTeamNumber())
+        flame:SetOwner(player)
+
+        local coords = Coords.GetTranslation(position)
+		
+		if math.abs(Math.DotProduct(normal, direction)) > 0.9999 then
+            direction = normal:GetPerpendicular()
+        end
+		
+        coords.yAxis = normal
+        coords.zAxis = direction
+
+        coords.xAxis = coords.yAxis:CrossProduct(coords.zAxis)
+        coords.xAxis:Normalize()
+
+        coords.zAxis = coords.xAxis:CrossProduct(coords.yAxis)
+        coords.zAxis:Normalize()
+
+        flame:SetCoords(coords)
+		
+    end
+
+end

--- a/src/lua/HallucinationCloak/Locale.lua
+++ b/src/lua/HallucinationCloak/Locale.lua
@@ -1,6 +1,6 @@
 
 local kLocales = {
-    HALLUCINATION_CLOUD = "Cloaking Cloud",
+    HALLUCINATION_CLOUD = "Cloaking Haze",
     HALLUCINATION_CLOUD_TOOLTIP = "Creates a cloud which cloaks players, eggs and drifters in target area.",
 }        
 


### PR DESCRIPTION

## ALIEN
### Hives
  - Reduced the additional 10% HP buff for maturity hives to 5%

### Fortress Shade
  - Hallucinations time duration removed
  - Able to transform into a random different structure
  - Added HP bars on hallucinations

### Whips
  - Increased turning speed before moving
  - Decreased rooting, unrooting time under frenzy
  - Reduced the cost of bile splash from 3 to 2 tres

### Fortress Structures
  - Converted 66% of their armor into HP (huge nerf to healing)
  - Increased cooldown for all fortress abilities from 10 to 15 seconds
  - reduced the cost of all fortress abilities from 3 to 2 tres
  - Fixed a bug which allowed abilities to being cast while under fire
  - No longer take 3x the damage off infestation in comparison to normal structures

### Drifter
  - Doesnt follow echoed unfinished structures over the entire map anymore
  
## MARINE
### Bugfixes 
  - Flying flamethrowers in rare cases should not crash the server anymore (vanilla bug)
  - Bot Commanders will research Exos, Weapon 3, Armor 3 again (balance mod bug)