### PR TITLE
Healing wave

### DIFF
--- a/src/lua/CommunityBalanceMod/FortressPvE/Crag.lua
+++ b/src/lua/CommunityBalanceMod/FortressPvE/Crag.lua
@@ -4,11 +4,11 @@ Crag.kHealInterval = 2
 Crag.kHealWaveInterval = 1
 Crag.kHealWaveMultiplier = 0.3  -- timing is independent of passive AOE
 
-Crag.kHealEffectInterval = 1.99  -- min delay for client effect
+Crag.kHealEffectInterval = 1.9  -- min delay for client effect, actual timing is based on server
 Crag.kHealWaveEffectInterval = 0.9 -- min delay for client effect
 
 Crag.kMinHeal = 8   -- was 7
-Crag.kMaxHeal = 60  -- was 48
+--Crag.kMaxHeal = 60  -- was 48
 
 Crag.kfortressCragMaterial = PrecacheAsset("models/alien/crag/crag_adv.material")
 Crag.kMoveSpeed = 2.9


### PR DESCRIPTION
Made Healing Wave timing independ of crag passive. Previously Healing Wave could be overriden by passive healing.
Healing Wave now instantly begins on activation and heals for 30% of passive healing, every 1 second (was 2 second).
Increased crag minimum healing on structures from 7 to 8.
Changed passive healing and healing wave visual effect frequency to match the timings of actual healing.