### PR TITLE
Railgun Bugfixes

### DIFF
--- a/src/lua/CommunityBalanceMod/FileHooks.lua
+++ b/src/lua/CommunityBalanceMod/FileHooks.lua
@@ -77,8 +77,8 @@ folder = "ScoreBuilding"
 Loader_SetupFilehook("lua/PointGiverMixin.lua", "post", folder)
 
 -- == Railgun dropoff ==
-folder = "RailgunDropoff"
-Loader_SetupFilehook("lua/Weapons/Marine/Railgun.lua", "post", folder)
+--folder = "RailgunDropoff"
+--Loader_SetupFilehook("lua/Weapons/Marine/Railgun.lua", "post", folder)
 
 -- == Passive ability for upgrades ==
 folder = "UpgradesPassiveAbilities"

--- a/src/lua/ModularExos/ExoWeapons/Railgun.lua
+++ b/src/lua/ModularExos/ExoWeapons/Railgun.lua
@@ -96,7 +96,14 @@ local function ExecuteShot(self, startPoint, endPoint, player)
 
     local hitEntities = {}
 	
-	for _ = 1, 20 do
+	local MaxTargets
+	if math.min(1, (Shared.GetTime() - self.timeChargeStarted) / kChargeTime) < 1 then
+		MaxTargets = 1
+	else
+		MaxTargets = 20
+	end
+	
+	for _ = 1, MaxTargets do
 
 		local capsuleTrace = Shared.TraceBox(extents, startPoint, trace.endPoint, CollisionRep.Damage, PhysicsMask.Bullets, filter)
 		if capsuleTrace.entity then


### PR DESCRIPTION
- Made it so only max charge pierces
- Disabled execute shot override from railgun falloff