### PR TITLE
Sentry balance

### DIFF
--- a/src/lua/Babbler.lua
+++ b/src/lua/Babbler.lua
@@ -1609,5 +1609,10 @@ function Babbler:OnDamageDone(doer, target)
     self.timeLastDamageDealt = Shared.GetTime()
 end
 
+function Babbler:GetCanGiveDamageOverride()
+    -- Babbler can hurt you
+    return true
+end
 
 Shared.LinkClassToMap("Babbler", Babbler.kMapName, networkVars, true)
+

--- a/src/lua/CommunityBalanceMod/Balance.lua
+++ b/src/lua/CommunityBalanceMod/Balance.lua
@@ -342,6 +342,8 @@ kSentryBuildTime = 8
 kSentryLimit = 2
 kSentryRange = 20
 kSentryBuildRange = 25 
+kSentryAttackBulletsPerSalvo = 2
+kSentryDamage = 3
 
 -- SMG Stuffz
 kSMGDamage = 12

--- a/src/lua/CommunityBalanceMod/BalanceMisc.lua
+++ b/src/lua/CommunityBalanceMod/BalanceMisc.lua
@@ -22,7 +22,7 @@ kSentrySupply = 10
 kSentryBatterySupply = 10
 kSentryBatteryCost = 10
 kSentryTargetAcquireTime = 0.23 -- was 0.15
-kSentrySpread = Math.Radians(6) -- was 3
+kSentrySpread = Math.Radians(7.5) -- was 3
 
 -- Sentry Battery
 kShieldBatteryUpgradeCost = 5

--- a/src/lua/CommunityBalanceMod/BalanceMisc.lua
+++ b/src/lua/CommunityBalanceMod/BalanceMisc.lua
@@ -21,6 +21,8 @@ kWelderSentryRepairRate = 90 -- 150 (90 is base, so no more super welding...)
 kSentrySupply = 10
 kSentryBatterySupply = 10
 kSentryBatteryCost = 10
+kSentryTargetAcquireTime = 0.23 -- was 0.15
+kSentrySpread = Math.Radians(6) -- was 3
 
 -- Sentry Battery
 kShieldBatteryUpgradeCost = 5

--- a/src/lua/Sentry.lua
+++ b/src/lua/Sentry.lua
@@ -250,8 +250,9 @@ function Sentry:OnInitialized()
             Sentry.kRange, 
             true,
             { kMarineStaticTargets, kMarineMobileTargets },
-            { PitchTargetFilter(self,  -Sentry.kMaxPitch, Sentry.kMaxPitch), CloakTargetFilter() },
-            { function(target) return target:isa("Player") end } )
+            { PitchTargetFilter(self,  -Sentry.kMaxPitch, Sentry.kMaxPitch), CloakTargetFilter() } --[[,
+            { function(target) return target:isa("Player") end } --]]
+            )
 
         InitMixin(self, StaticTargetMixin)
         InitMixin(self, InfestationTrackerMixin)
@@ -756,3 +757,4 @@ function Sentry:GetRequiresPower()
 end
 
 Shared.LinkClassToMap("Sentry", Sentry.kMapName, networkVars)
+


### PR DESCRIPTION
Increased Sentry target acquisitioin delay from 0.15 to 0.23.
Increased Sentry spread from 3 to 7.5 degrees.
Sentry shoots two bullets of 3 damage instead of one of 5 damage.
Babblers now correctly count as damage dealers for targetting priority.
Sentries now prioritize all damage dealers instead of players.