### PR TITLE
Fix crag shade shift spur lag compensation

### DIFF
--- a/src/lua/Crag.lua
+++ b/src/lua/Crag.lua
@@ -99,7 +99,10 @@ local networkVars =
     
     moving = "boolean",
 	infestationSpeedCharge = "float",
-	electrified = "boolean"
+	electrified = "boolean",
+
+    -- lag compensated model origin 
+    m_origin = "compensated interpolated position (by 0.05 [2 3 5], by 0.05 [2 3 5], by 0.05 [2 3 5])",
 }
 
 AddMixinNetworkVars(BaseModelMixin, networkVars)
@@ -617,7 +620,7 @@ function Crag:PerformDouse()
 	
 end
 
-Shared.LinkClassToMap("Crag", Crag.kMapName, networkVars)
+Shared.LinkClassToMap("Crag", Crag.kMapName, networkVars, true)
 
 class 'FortressCrag' (Crag)
 FortressCrag.kMapName = "fortresscrag"
@@ -769,4 +772,5 @@ end
 
 function Crag:GetElectrified()
     return self.electrified
+
 end

--- a/src/lua/Shade.lua
+++ b/src/lua/Shade.lua
@@ -92,7 +92,10 @@ Shade.kSonarParaTime = 5.5
 local networkVars = { 
     moving = "boolean",
 	infestationSpeedCharge = "float",
-	electrified = "boolean"
+	electrified = "boolean",
+	
+	-- lag compensated model origin 
+    m_origin = "compensated interpolated position (by 0.05 [2 3 5], by 0.05 [2 3 5], by 0.05 [2 3 5])",
 }
 
 AddMixinNetworkVars(BaseModelMixin, networkVars)
@@ -470,7 +473,7 @@ function Shade:GetTechAllowed(techId, techNode, player)
     
 end
 
-Shared.LinkClassToMap("Shade", Shade.kMapName, networkVars)
+Shared.LinkClassToMap("Shade", Shade.kMapName, networkVars, true)
 
 -- %%% New CBM Functions %%% --
 function Shade:GetOffInfestationHurtPercentPerSecond()
@@ -662,4 +665,5 @@ end
 
 function Shade:GetElectrified()
     return self.electrified
+
 end

--- a/src/lua/Shift.lua
+++ b/src/lua/Shift.lua
@@ -113,7 +113,10 @@ local networkVars =
     
     moving = "boolean",
 	infestationSpeedCharge = "float",
-	electrified = "boolean"
+	electrified = "boolean",
+    
+    -- lag compensated model origin 
+    m_origin = "compensated interpolated position (by 0.05 [2 3 5], by 0.05 [2 3 5], by 0.05 [2 3 5])",
 }
 
 AddMixinNetworkVars(BaseModelMixin, networkVars)
@@ -773,7 +776,7 @@ function Shift:GetCanBeUsed(player, useSuccessTable)
     useSuccessTable.useSuccess = false    
 end
 
-Shared.LinkClassToMap("Shift", Shift.kMapName, networkVars)
+Shared.LinkClassToMap("Shift", Shift.kMapName, networkVars, true)
 
 -- %%% New CBM Functions %%% --
 function Shift:GetOffInfestationHurtPercentPerSecond()
@@ -1146,4 +1149,5 @@ end
 function Shift:GetElectrified()
     return self.electrified
 end
+
 

--- a/src/lua/Spur.lua
+++ b/src/lua/Spur.lua
@@ -57,7 +57,10 @@ Spur.kMoveSpeed = 2.9 / 2
 
 local networkVars = 
 { 
-	electrified = "boolean"
+	electrified = "boolean",
+
+    -- lag compensated model origin 
+    m_origin = "compensated interpolated position (by 0.05 [2 3 5], by 0.05 [2 3 5], by 0.05 [2 3 5])",
 }
 
 AddMixinNetworkVars(BaseModelMixin, networkVars)
@@ -125,7 +128,7 @@ function Spur:OnCreate()
         InitMixin(self, CommanderGlowMixin)    
     end
     
-    self:SetLagCompensated(false)
+    --self:SetLagCompensated(false) -- this does nothing
     self:SetPhysicsType(PhysicsType.Kinematic)
     self:SetPhysicsGroup(PhysicsGroup.MediumStructuresGroup)
     
@@ -242,7 +245,7 @@ end
 
 -- %%% New CBM Functions %%% --
 function Spur:GetMaxSpeed()
-    return Spur.kMoveSpeed
+    return Spur.kMoveSpeed --self.electrified and 0 or Spur.kMoveSpeed
 end
 
 function Spur:OverrideRepositioningSpeed()
@@ -253,6 +256,9 @@ function Spur:GetCanReposition()
     return true
 end
 
+function Spur:GetStructureMoveable()
+    return not self.electrified
+end
 function Spur:OnOrderChanged()
     if self:GetIsConsuming() then
         self:CancelResearch()
@@ -271,7 +277,7 @@ function Spur:PerformAction(techNode)
     end
 end
 
-Shared.LinkClassToMap("Spur", Spur.kMapName, networkVars)
+Shared.LinkClassToMap("Spur", Spur.kMapName, networkVars, true)
 
 if Client then
     
@@ -305,12 +311,6 @@ function Spur:OnUpdate(deltaTime)
 
     if Server then
 		self.electrified = self.timeElectrifyEnds > Shared.GetTime()
-		
-        if self.electrified then
-			Spur.kMoveSpeed = 0
-		else
-			Spur.kMoveSpeed = 2.9 / 2
-		end
     end
 end
 
@@ -322,4 +322,5 @@ function Spur:SetElectrified(time)
         self.electrified = true
 
     end
+
 end


### PR DESCRIPTION
Changed m_origin network field of Crag, Shade, Shift and Spur to an approximate lag compensated position.
Refactored Spur movement speed, using Spur:GetStructureMoveable() to enable/disable movement when electrified.