### PR TITLE
Fix mines

### DIFF
--- a/src/lua/Mine.lua
+++ b/src/lua/Mine.lua
@@ -6,6 +6,15 @@
 --
 -- ========= For more information, visit us at http://www.unknownworlds.com =====================
 
+-- Behavior notes:
+--  Mines perform their detonation check two ways:
+--  1. Via the TriggerMixin, which will call self:OnTriggerEntered(). It's a responsive call.
+--     This works for every entity entering the hitbox radius set by SetSphere().
+--     However, if an alien is not in LoS at that moment, then there is no recheck.
+-- 2. The OnUpdate() will take any other cases and deal with the limitation of the first.
+--    It might be off by a bit (compared to the trigger and because it has a refresh rate),
+--    but it's good enough and works in most cases.
+
 Script.Load("lua/ScriptActor.lua")
 Script.Load("lua/TriggerMixin.lua")
 Script.Load("lua/StunMixin.lua")
@@ -24,7 +33,6 @@ Script.Load("lua/PointGiverMixin.lua")
 Script.Load("lua/Ragdoll.lua")
 Script.Load("lua/MapBlipMixin.lua")
 Script.Load("lua/CombatMixin.lua")
-Script.Load("lua/BlightMixin.lua")
 
 class 'Mine' (ScriptActor)
 
@@ -56,7 +64,6 @@ AddMixinNetworkVars(TeamMixin, networkVars)
 AddMixinNetworkVars(ParasiteMixin, networkVars)
 AddMixinNetworkVars(LOSMixin, networkVars)
 AddMixinNetworkVars(CombatMixin, networkVars)
-AddMixinNetworkVars(BlightMixin, networkVars)
 
 function Mine:OnCreate()
     
@@ -74,7 +81,6 @@ function Mine:OnCreate()
     InitMixin(self, LOSMixin)
     InitMixin(self, PointGiverMixin)
     InitMixin(self, CombatMixin)
-	InitMixin(self, BlightMixin)
     
     if Client then
         InitMixin(self, MarineOutlineMixin)
@@ -110,12 +116,12 @@ end
 
 function Mine:Detonate()
     if not self.active then return end
-    
-    local hitEntities = GetEntitiesWithMixinWithinRange("Live", self:GetOrigin(), kMineDetonateRange)
-    RadiusDamage(hitEntities, self:GetOrigin(), kMineDetonateRange, kMineDamage, self, false, SineFalloff)
+
+    local hitEntities = GetEntitiesWithMixinWithinRange("Live", self:GetAttachPointOriginHardcoded(), kMineDetonateRange)
+    RadiusDamage(hitEntities, self:GetAttachPointOriginHardcoded(), kMineDetonateRange, kMineDamage, self, false, SineFalloff)
     
     -- Start the timed destruction sequence for any mine within range of this exploded mine.
-    local nearbyMines = GetEntitiesWithinRange("Mine", self:GetOrigin(), kMineChainDetonateRange)
+    local nearbyMines = GetEntitiesWithinRange("Mine", self:GetAttachPointOriginHardcoded(), kMineChainDetonateRange)
     for _, mine in ipairs(nearbyMines) do
         
         if mine ~= self and not mine.armed then
@@ -189,7 +195,7 @@ function Mine:CheckEntityExplodesMine(entity)
     
     end
     
-    local minePos = self:GetEngagementPoint()
+    local minePos = self:GetAttachPointOriginHardcoded()
     local targetPos = entity:GetEngagementPoint()
     -- Do not trigger through walls. But do trigger through other entities.
     if not GetWallBetween(minePos, targetPos, entity) then
@@ -233,10 +239,9 @@ function Mine:OnInitialized()
         self:PlaySound(kWarmupSound)
         
         InitMixin(self, TriggerMixin)
-        self:SetSphere(kMineTriggerRange)
-    
+        self:SetSphere(kMineTriggerRange) -- Calls 
     end
-    
+
     self:SetModel(Mine.kModelName)
 
 end
@@ -307,11 +312,10 @@ if Server then
     function Mine:OnUpdate()
         
         local now = Shared.GetTime()
-        self.lastMineUpdateTime = self.lastMineUpdateTime or now
-        if now - self.lastMineUpdateTime >= 0.5 then
-            
+        self.nextMineUpdateTime = self.nextMineUpdateTime or now
+        if now >= self.nextMineUpdateTime then
             self:CheckAllEntsInTriggerExplodeMine()
-            self.lastMineUpdateTime = now
+            self.nextMineUpdateTime = now + (self:GetCanSleep() and 0.4 or 0.1)
         
         end
     
@@ -343,6 +347,7 @@ function Mine:GetTechButtons(techId)
 end
 
 function Mine:GetAttachPointOriginHardcoded()
+    -- Elevates slightly above origin point to account for map features
     return self:GetOrigin() + self:GetCoords().yAxis * 0.01
 end
 


### PR DESCRIPTION
Adding two fixed. The first is a change into the coords used to look for enemies and deal damages, which was in the wall and could lead to mines detonating and doing 0 damages. The second is the OnUpdate(). Because it was way too slow, it failed to catch up instances not caught by the trigger mixin (because out of LoS). Instead, it is not dynamically adjusting its update rate and is responsive if aliens are nearby.