### PR TITLE
Minor drifter selection fix

### DIFF
--- a/src/lua/Alien.lua
+++ b/src/lua/Alien.lua
@@ -132,10 +132,10 @@ AddMixinNetworkVars(ShieldableMixin, networkVars)
 AddMixinNetworkVars(GUINotificationMixin, networkVars)
 AddMixinNetworkVars(PlayerStatusMixin, networkVars)
 
-local function GetNearest(self, className)
+local function GetNearest(origin, teamNumber, className)
 
-    local ents = GetEntitiesForTeam(className, self:GetTeamNumber())
-    Shared.SortEntitiesByDistance(self:GetOrigin(), ents)
+    local ents = GetEntitiesForTeam(className, teamNumber)
+    Shared.SortEntitiesByDistance(origin, ents)
     
     return ents[1]
 
@@ -568,7 +568,7 @@ end
 
 function Alien:PerformActivation(techId, position, normal, commander)
 
-    local nearestDrifter = GetNearest(self, "Drifter")
+    local nearestDrifter = GetNearest(position, self:GetTeamNumber(), "Drifter")
 
     --Log("Alien -- PerformActivation() called")
     if (nearestDrifter) then -- Forward the call


### PR DESCRIPTION
- If the khamm uses the alien button selection to cast a drifter castable, it will now selects the nearest drifter from the cast target location, rather than the selected alien(s).

This makes the behavior consistent regardless of which alien is selected, and will work even if a pack+drifter(s) is group selected.